### PR TITLE
Delete hashtags when a post is deleted

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { prisma } from "@/lib/prisma";
+import { deleteHashtags } from "@/features/explore/api/delete-hashtags";
+import { retrieveHashtagsFromPost } from "@/features/explore/api/retrieve-hashtags-from-post";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -263,11 +265,28 @@ export async function DELETE(request: Request) {
   }
 
   try {
+    const post = await prisma.post.findUnique({
+      where: {
+        id,
+      },
+      select: {
+        text: true,
+      },
+    });
+
+    if (post) {
+      const hashtags = retrieveHashtagsFromPost(post.text);
+      if (hashtags) {
+        await deleteHashtags(hashtags);
+      }
+    }
+
     await prisma.post.delete({
       where: {
         id,
       },
     });
+
     return NextResponse.json({
       message: "Post deleted successfully",
     });

--- a/src/features/posts/api/delete-post.ts
+++ b/src/features/posts/api/delete-post.ts
@@ -1,7 +1,26 @@
 import axios from "axios";
+import { deleteHashtags } from "@/features/explore/api/delete-hashtags";
+import { retrieveHashtagsFromPost } from "@/features/explore/api/retrieve-hashtags-from-post";
+import { prisma } from "@/lib/prisma";
 
 export const deletePost = async (postId: string) => {
   try {
+    const post = await prisma.post.findUnique({
+      where: {
+        id: postId,
+      },
+      select: {
+        text: true,
+      },
+    });
+
+    if (post) {
+      const hashtags = retrieveHashtagsFromPost(post.text);
+      if (hashtags) {
+        await deleteHashtags(hashtags);
+      }
+    }
+
     const { data } = await axios.delete(`/api/posts?id=${postId}`);
 
     return data;


### PR DESCRIPTION
Add functionality to delete hashtags when a post is deleted.

* Import `deleteHashtags` and `retrieveHashtagsFromPost` from `@/features/explore/api/delete-hashtags` and `@/features/explore/api/retrieve-hashtags-from-post` in `src/app/api/posts/route.ts`.
* Retrieve post text from Prisma in the `DELETE` function in `src/app/api/posts/route.ts`.
* Use `retrieveHashtagsFromPost` to extract hashtags from the post text in `src/app/api/posts/route.ts`.
* Use `deleteHashtags` to delete extracted hashtags in `src/app/api/posts/route.ts`.
* Import `deleteHashtags` and `retrieveHashtagsFromPost` from `@/features/explore/api/delete-hashtags` and `@/features/explore/api/retrieve-hashtags-from-post` in `src/features/posts/api/delete-post.ts`.
* Retrieve post text from Prisma before deleting the post in `src/features/posts/api/delete-post.ts`.
* Use `retrieveHashtagsFromPost` to extract hashtags from the post text in `src/features/posts/api/delete-post.ts`.
* Use `deleteHashtags` to delete extracted hashtags in `src/features/posts/api/delete-post.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OxyHQ/Mention/pull/62?shareId=6d80e616-25ad-4e75-8747-12ffa9c1c21f).