### PR TITLE
Use resolved expo-router entry point

### DIFF
--- a/packages/frontend/app.config.js
+++ b/packages/frontend/app.config.js
@@ -29,7 +29,7 @@ return {
       scheme: 'mention',
       userInterfaceStyle: 'automatic',
       newArchEnabled: true,
-      entryPoint: "./expo-router/entry",
+      entryPoint: require.resolve('expo-router/entry'),
       experiments: {
         autolinkingModuleResolution: true,
       },


### PR DESCRIPTION
## Summary
- resolve the Expo Router entry module path in app.config.js so Metro can locate the hoisted dependency

## Testing
- EXPO_OFFLINE=1 npm run web --workspace=@mention/frontend

------
https://chatgpt.com/codex/tasks/task_e_690a5fc6dfac8328accdd236ada30e10