### PR TITLE
Fix web platform compatibility and improve socket health monitoring

### DIFF
--- a/packages/frontend/app/settings/profile-customization.tsx
+++ b/packages/frontend/app/settings/profile-customization.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Animated } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Animated, Platform } from 'react-native';
 import { useAppearanceStore } from '@/store/appearanceStore';
 import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
@@ -70,8 +70,8 @@ export default function ProfileCustomizationScreen() {
   useEffect(() => {
     const anim = Animated.loop(
       Animated.sequence([
-        Animated.timing(pulseAnim, { toValue: 1, duration: 1000, useNativeDriver: true }),
-        Animated.timing(pulseAnim, { toValue: 0.5, duration: 1000, useNativeDriver: true }),
+        Animated.timing(pulseAnim, { toValue: 1, duration: 1000, useNativeDriver: Platform.OS !== 'web' }),
+        Animated.timing(pulseAnim, { toValue: 0.5, duration: 1000, useNativeDriver: Platform.OS !== 'web' }),
       ])
     );
     anim.start();

--- a/packages/frontend/components/AppSplashScreen.tsx
+++ b/packages/frontend/components/AppSplashScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useMemo, useRef } from 'react';
-import { View, Animated, StyleSheet } from 'react-native';
+import { View, Animated, StyleSheet, Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { cssInterop } from 'nativewind';
 import { LogoIcon } from '@/assets/logo';
@@ -48,7 +48,7 @@ const AppSplashScreen: React.FC<AppSplashScreenProps> = ({
             animationRef.current = Animated.timing(fadeAnim, {
                 toValue: 0,
                 duration: FADE_DURATION,
-                useNativeDriver: true,
+                useNativeDriver: Platform.OS !== 'web',
             });
 
             animationRef.current.start(({ finished }) => {

--- a/packages/frontend/components/BottomBar.tsx
+++ b/packages/frontend/components/BottomBar.tsx
@@ -132,10 +132,8 @@ export const BottomBar = () => {
         },
     });
 
-    const AnimatedView = Animated.createAnimatedComponent(View);
-
     return (
-        <AnimatedView style={[styles.bottomBar, bottomBarAnimatedStyle]}>
+        <Animated.View style={[styles.bottomBar, bottomBarAnimatedStyle]}>
             <Pressable onPress={handleHomePress} style={[styles.tab, pathname === '/' && styles.active]}>
                 {pathname === '/' ? (
                     <HomeActive size={28} color={effectiveTheme.colors.primary} />
@@ -180,6 +178,6 @@ export const BottomBar = () => {
             >
                 <Avatar size={35} source={{ uri: user?.avatar ? oxyServices.getFileDownloadUrl(user.avatar as string, 'thumb') : undefined }} />
             </Pressable>
-        </AnimatedView>
+        </Animated.View>
     );
 };

--- a/packages/frontend/components/Toggle.tsx
+++ b/packages/frontend/components/Toggle.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Animated } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Animated, Platform } from 'react-native';
 import { useTheme } from '@/hooks/useTheme';
 
 interface ToggleProps {
@@ -24,7 +24,7 @@ export const Toggle: React.FC<ToggleProps> = ({
     Animated.timing(switchAnimation, {
       toValue: value ? 1 : 0,
       duration: 200,
-      useNativeDriver: true,
+      useNativeDriver: Platform.OS !== 'web',
     }).start();
   }, [value]);
 

--- a/packages/frontend/components/common/AnimatedNumber.tsx
+++ b/packages/frontend/components/common/AnimatedNumber.tsx
@@ -3,6 +3,8 @@ import { Text, TextProps } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, interpolate, useAnimatedReaction, runOnJS } from 'react-native-reanimated';
 import { formatCompactNumber } from '@/utils/formatNumber';
 
+const AnimatedText = Animated.createAnimatedComponent(Text);
+
 interface AnimatedNumberProps extends Omit<TextProps, 'children'> {
     value: number;
     duration?: number;
@@ -65,9 +67,6 @@ const AnimatedNumber: React.FC<AnimatedNumberProps> = ({
         };
     });
 
-    // Use Animated.Text for smoother updates
-    const DisplayTag = Animated.createAnimatedComponent(Text);
-
     // Format number for display (e.g., 1.2K, 1.5M)
     const formatNumber = React.useCallback((n: number): string => {
         if (format) return format(n);
@@ -75,9 +74,9 @@ const AnimatedNumber: React.FC<AnimatedNumberProps> = ({
     }, [format]);
 
     return (
-        <DisplayTag {...textProps} style={[style, animStyle]}>
+        <AnimatedText {...textProps} style={[style, animStyle]}>
             {formatNumber(display)}
-        </DisplayTag>
+        </AnimatedText>
     );
 };
 

--- a/packages/frontend/context/LayoutScrollContext.tsx
+++ b/packages/frontend/context/LayoutScrollContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useRef } from 'react';
 import { Animated, Platform } from 'react-native';
 
 type ScrollEvent = {
@@ -82,7 +82,7 @@ export function LayoutScrollProvider({
     children,
     scrollEventThrottle = 16,
 }: LayoutScrollProviderProps) {
-    const scrollY = useMemo(() => new Animated.Value(0), []);
+    const scrollY = useRef(new Animated.Value(0)).current;
     const scrollableRef = useRef<ScrollableRef | null>(null);
     const scrollElementRef = useRef<HTMLElement | null>(null);
     const scrollPositionRef = useRef(0);


### PR DESCRIPTION
## Summary
This PR addresses web platform compatibility issues in React Native animations and improves the socket connection health monitoring system to be more resilient against false positives.

## Key Changes

### Web Platform Compatibility
- Added `Platform` import and conditional `useNativeDriver` settings across animation components to disable native driver on web platform (where it's not supported):
  - `profile-customization.tsx`: Pulse animation
  - `AppSplashScreen.tsx`: Fade animation
  - `Toggle.tsx`: Switch animation
- Simplified `BottomBar.tsx` by using `Animated.View` directly instead of creating a separate animated component
- Optimized `AnimatedNumber.tsx` by moving `AnimatedText` component creation outside the render function
- Fixed `LayoutScrollContext.tsx` to use `useRef` instead of `useMemo` for `Animated.Value` initialization

### Socket Health Monitoring Improvements
- Added consecutive failure tracking to prevent reconnection loops caused by temporary network hiccups
- Implemented `MAX_HEALTH_FAILURES` threshold (3 consecutive failures) before triggering reconnection
- Added `healthCheckDisconnect` flag to distinguish health-check-triggered reconnects from other disconnects
- Reset failure counter on successful pong responses
- Added fallback listener for Socket.IO's transport-level pong events for better compatibility
- Improved health check logic to only increment failure counter when connection is actually unhealthy
- Enhanced logging to show number of consecutive failures before reconnecting

## Implementation Details
- The health monitoring now requires 3 consecutive 60-second timeout periods before reconnecting, reducing false positives
- The `healthCheckDisconnect` flag ensures that reconnect attempt counters aren't reset unnecessarily during health-check-triggered reconnects
- Web platform animations now gracefully degrade by disabling the native driver, which is unsupported in web environments

https://claude.ai/code/session_01FbpTTsn1V9y3QfonsGXyVR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
