### PR TITLE
feat: implement missing post actions (unpin, hide counts, reply permissions)

### DIFF
--- a/packages/backend/src/models/Post.ts
+++ b/packages/backend/src/models/Post.ts
@@ -194,6 +194,7 @@ const PostMetadataSchema = new Schema({
   isFollowingAuthor: { type: Boolean, default: false },
   authorBlocked: { type: Boolean, default: false },
   authorMuted: { type: Boolean, default: false },
+  hideEngagementCounts: { type: Boolean, default: false },
   // Track user interactions
   likedBy: [{ type: String }], // Array of user IDs who liked this post
   savedBy: [{ type: String }],  // Array of user IDs who saved this post

--- a/packages/backend/src/routes/posts.ts
+++ b/packages/backend/src/routes/posts.ts
@@ -5,6 +5,7 @@ import {
   getPosts,
   getPostById,
   updatePost,
+  updatePostSettings,
   deletePost,
   likePost,
   unlikePost,
@@ -50,6 +51,7 @@ router.get('/:id', getPostById);
 
 // Protected routes with parameters
 router.put('/:id', updatePost);
+router.patch('/:id/settings', updatePostSettings);
 router.delete('/:id', deletePost);
 router.post('/:id/like', likePost);
 router.delete('/:id/like', unlikePost);

--- a/packages/backend/src/routes/search.ts
+++ b/packages/backend/src/routes/search.ts
@@ -90,7 +90,7 @@ router.get("/", async (req: AuthRequest, res: Response) => {
       }
 
       // Media filters
-      if (hasMedia === 'true' || hasMedia === true) {
+      if (hasMedia === 'true') {
         filter['content.media'] = { $exists: true, $ne: null };
       }
 

--- a/packages/backend/src/services/TrendingService.ts
+++ b/packages/backend/src/services/TrendingService.ts
@@ -188,12 +188,12 @@ class TrendingService {
       const trending = await Trending.find({ timeWindow })
         .sort({ score: -1, rank: 1 })
         .limit(limit)
-        .lean();
+        .lean() as ITrending[];
 
       // Cache the result
       if (redis && trending.length > 0) {
         try {
-          await redis.setex(cacheKey, this.REDIS_CACHE_TTL, JSON.stringify(trending));
+          await redis.setEx(cacheKey, this.REDIS_CACHE_TTL, JSON.stringify(trending));
           logger.debug(`[Trending] Cached ${trending.length} items for ${timeWindow}`);
         } catch (cacheError) {
           logger.warn('[Trending] Redis cache write failed:', cacheError);
@@ -220,7 +220,7 @@ class TrendingService {
       const keys = await redis.keys(pattern);
 
       if (keys.length > 0) {
-        await redis.del(...keys);
+        await redis.del(keys);
         logger.debug(`[Trending] Invalidated ${keys.length} cache keys`);
       }
     } catch (error) {

--- a/packages/backend/src/services/TrendingService.ts
+++ b/packages/backend/src/services/TrendingService.ts
@@ -188,7 +188,7 @@ class TrendingService {
       const trending = await Trending.find({ timeWindow })
         .sort({ score: -1, rank: 1 })
         .limit(limit)
-        .lean() as ITrending[];
+        .lean() as unknown as ITrending[];
 
       // Cache the result
       if (redis && trending.length > 0) {

--- a/packages/frontend/hooks/usePostActions.tsx
+++ b/packages/frontend/hooks/usePostActions.tsx
@@ -139,18 +139,27 @@ export function usePostActions({
                 icon: <UnpinIcon size={20} color={theme.colors.textSecondary} />,
                 text: "Unpin",
                 onPress: async () => {
-                    // TODO: Implement unpin functionality
+                    try {
+                        await feedService.updatePostSettings(postId, { isPinned: false });
+                    } catch (e) {
+                        Alert.alert('Error', 'Failed to unpin post');
+                    }
                     bottomSheet.openBottomSheet(false);
                 }
             });
         }
 
         if (isOwner) {
+            const isHidden = Boolean(viewPost?.metadata?.hideEngagementCounts);
             saveActionGroup.push({
                 icon: <HideIcon size={20} color={theme.colors.textSecondary} />,
-                text: "Hide like and share counts",
+                text: isHidden ? "Show like and share counts" : "Hide like and share counts",
                 onPress: async () => {
-                    // TODO: Implement hide counts functionality
+                    try {
+                        await feedService.updatePostSettings(postId, { hideEngagementCounts: !isHidden });
+                    } catch (e) {
+                        Alert.alert('Error', 'Failed to update engagement count visibility');
+                    }
                     bottomSheet.openBottomSheet(false);
                 }
             });
@@ -164,14 +173,20 @@ export function usePostActions({
                     bottomSheet.setBottomSheetContent(
                         <ReplySettingsSheet
                             replyPermission={viewPost?.replyPermission || 'anyone'}
-                            onReplyPermissionChange={(permission) => {
-                                // TODO: Implement update reply permission
-                                console.log('Update reply permission:', permission);
+                            onReplyPermissionChange={async (permission) => {
+                                try {
+                                    await feedService.updatePostSettings(postId, { replyPermission: permission });
+                                } catch (e) {
+                                    Alert.alert('Error', 'Failed to update reply permissions');
+                                }
                             }}
                             reviewReplies={viewPost?.reviewReplies || false}
-                            onReviewRepliesChange={(enabled) => {
-                                // TODO: Implement update review replies
-                                console.log('Update review replies:', enabled);
+                            onReviewRepliesChange={async (enabled) => {
+                                try {
+                                    await feedService.updatePostSettings(postId, { reviewReplies: enabled });
+                                } catch (e) {
+                                    Alert.alert('Error', 'Failed to update review replies setting');
+                                }
                             }}
                             onClose={() => bottomSheet.openBottomSheet(false)}
                         />

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -486,6 +486,23 @@ class FeedService {
   }
 
   /**
+   * Update post settings (pin, hide counts, reply permissions, review replies)
+   */
+  async updatePostSettings(postId: string, settings: {
+    isPinned?: boolean;
+    hideEngagementCounts?: boolean;
+    replyPermission?: 'anyone' | 'followers' | 'following' | 'mentioned';
+    reviewReplies?: boolean;
+  }): Promise<{ success: boolean; data: any }> {
+    try {
+      const response = await authenticatedClient.patch(`/posts/${postId}/settings`, settings);
+      return { success: true, data: response.data };
+    } catch (error) {
+      throw new Error('Failed to update post settings');
+    }
+  }
+
+  /**
    * Delete a post
    */
   async deletePost(postId: string): Promise<{ success: boolean }> {

--- a/packages/shared-types/src/post.ts
+++ b/packages/shared-types/src/post.ts
@@ -120,6 +120,7 @@ export interface PostMetadata {
   isFollowingAuthor?: boolean;
   authorBlocked?: boolean;
   authorMuted?: boolean;
+  hideEngagementCounts?: boolean;
   // Track user interactions
   likedBy?: string[]; // Array of user IDs who liked this post
   savedBy?: string[]; // Array of user IDs who saved this post
@@ -246,6 +247,7 @@ export interface PostMetadataState {
   reviewReplies?: boolean;
   isPinned?: boolean;
   isSensitive?: boolean;
+  hideEngagementCounts?: boolean;
   isThread?: boolean;
   language?: string;
   tags?: string[];


### PR DESCRIPTION
## Summary
- Add `PATCH /posts/:id/settings` backend endpoint for updating post settings (isPinned, hideEngagementCounts, replyPermission, reviewReplies) with ownership validation and input type checking
- Add `hideEngagementCounts` field to Post model schema and shared types
- Implement all 4 TODO stubs in `usePostActions.tsx` with real API calls via `feedService.updatePostSettings()`
- Fix pre-existing TypeScript build errors in `search.ts` and `TrendingService.ts`

## Test plan
- [ ] Verify PATCH `/posts/:id/settings` returns 401 for unauthenticated users
- [ ] Verify PATCH `/posts/:id/settings` returns 404 for non-owner
- [ ] Verify unpin action sets `metadata.isPinned` to false
- [ ] Verify hide counts toggle updates `metadata.hideEngagementCounts`
- [ ] Verify reply permission update accepts valid values and rejects invalid ones
- [ ] Verify review replies toggle updates `reviewReplies` field
- [ ] Verify backend TypeScript compiles without errors

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
