### PR TITLE
fix: federation posts not visible from other fediverse servers

### DIFF
--- a/packages/backend/src/mtn/controllers/feed.controller.ts
+++ b/packages/backend/src/mtn/controllers/feed.controller.ts
@@ -16,6 +16,38 @@ import { trackFeedInteraction } from '../feed/FeedInteractionTracker';
 import { logger } from '../../utils/logger';
 import { oxy as oxyClient } from '../../../server';
 import { extractFollowingIds } from '../../utils/privacyHelpers';
+import FederatedFollow from '../../models/FederatedFollow';
+import FederatedActor from '../../models/FederatedActor';
+
+/**
+ * Merge oxyUserIds from accepted federated (ActivityPub) follows into the
+ * given followingIds array, deduplicating in-place.
+ */
+async function mergeFederatedFollowIds(
+  localUserId: string,
+  followingIds: string[],
+): Promise<void> {
+  const fedFollowUris = await FederatedFollow.distinct('remoteActorUri', {
+    localUserId,
+    direction: 'outbound',
+    status: 'accepted',
+  });
+  if (fedFollowUris.length === 0) return;
+
+  const fedActors = await FederatedActor.find(
+    { uri: { $in: fedFollowUris }, oxyUserId: { $ne: null } },
+    { oxyUserId: 1 },
+  ).lean();
+
+  const existing = new Set(followingIds);
+  for (const actor of fedActors) {
+    const id = actor.oxyUserId;
+    if (id && !existing.has(id)) {
+      followingIds.push(id);
+      existing.add(id);
+    }
+  }
+}
 
 class MtnFeedController {
   /**
@@ -52,6 +84,12 @@ class MtnFeedController {
           followingIds = extractFollowingIds(followingRes);
         } catch (error) {
           logger.warn('[MtnFeedController] Failed to load following list', error);
+        }
+
+        try {
+          await mergeFederatedFollowIds(currentUserId, followingIds);
+        } catch (error) {
+          logger.warn('[MtnFeedController] Failed to load federated following', error);
         }
       }
 
@@ -135,6 +173,12 @@ class MtnFeedController {
           followingIds = extractFollowingIds(followingRes);
         } catch (error) {
           logger.warn('[MtnFeedController] Failed to load following list', error);
+        }
+
+        try {
+          await mergeFederatedFollowIds(currentUserId, followingIds);
+        } catch (error) {
+          logger.warn('[MtnFeedController] Failed to load federated following', error);
         }
       }
 

--- a/packages/backend/src/services/FederationService.ts
+++ b/packages/backend/src/services/FederationService.ts
@@ -671,12 +671,13 @@ class FederationService {
     const actor = await this.getOrFetchActor(remoteActorUri);
     if (!actor) return { success: false, pending: false };
 
+    const canonicalUri = actor.uri; // Use canonical URI from fetched actor
     const localActorUri = actorUrl(localUsername);
     const activityId = `${localActorUri}/follows/${actor._id}`;
 
     // Create or update the follow record
     await FederatedFollow.findOneAndUpdate(
-      { localUserId: localOxyUserId, remoteActorUri, direction: 'outbound' },
+      { localUserId: localOxyUserId, remoteActorUri: canonicalUri, direction: 'outbound' },
       { $set: { status: 'pending', activityId } },
       { upsert: true, returnDocument: 'after' },
     );
@@ -686,7 +687,7 @@ class FederationService {
       id: activityId,
       type: 'Follow',
       actor: localActorUri,
-      object: remoteActorUri,
+      object: canonicalUri,
     };
 
     const delivered = await this.deliverActivity(activity, actor.inboxUrl, localOxyUserId, localUsername);
@@ -1001,17 +1002,42 @@ class FederationService {
     const object = activity.object;
     if (!object) return;
 
-    const objectType = typeof object === 'string' ? null : object.type;
-    if (objectType === 'Follow') {
-      const followActivityId = typeof object === 'object' ? object.id : undefined;
+    let updated = false;
+
+    if (typeof object === 'string') {
+      // Remote sent Accept with a string reference (the Follow activity ID)
+      const filter: Record<string, unknown> = {
+        remoteActorUri: actorUri,
+        direction: 'outbound',
+        status: 'pending',
+      };
+      // Try matching by activityId first, fall back to any pending follow
+      let result = await FederatedFollow.updateOne({ ...filter, activityId: object }, { $set: { status: 'accepted' } });
+      if ((result?.modifiedCount ?? 0) === 0) {
+        result = await FederatedFollow.updateOne(filter, { $set: { status: 'accepted' } });
+      }
+      updated = (result?.modifiedCount ?? 0) > 0;
+    } else if (object.type === 'Follow') {
+      const followActivityId = object.id;
       const filter: Record<string, unknown> = {
         remoteActorUri: actorUri,
         direction: 'outbound',
         status: 'pending',
       };
       if (followActivityId) filter.activityId = followActivityId;
-      await FederatedFollow.updateOne(filter, { $set: { status: 'accepted' } });
+      const result = await FederatedFollow.updateOne(filter, { $set: { status: 'accepted' } });
+      updated = (result?.modifiedCount ?? 0) > 0;
+    }
+
+    if (updated) {
       logger.debug(`Follow accepted by ${actorUri}`);
+      // Fire-and-forget: backfill the newly followed actor's recent posts
+      const actor = await FederatedActor.findOne({ uri: actorUri }).lean();
+      if (actor) {
+        this.syncOutboxPosts(actor, 20).catch(err =>
+          logger.warn(`Failed to sync outbox after accept from ${actorUri}: ${err}`),
+        );
+      }
     }
   }
 

--- a/packages/frontend/components/Profile/ProfileContent.tsx
+++ b/packages/frontend/components/Profile/ProfileContent.tsx
@@ -98,6 +98,7 @@ export const ProfileContent = memo(function ProfileContent({
           <ProfileActions
             isOwnProfile={isOwnProfile}
             isFederated={profileData.isFederated}
+            actorUri={profileData.actorUri}
             currentUsername={currentUsername}
             profileUsername={profileData.username}
             profileId={profileData.id}

--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -11,6 +11,7 @@ import { Gear } from '@/assets/icons/gear-icon';
 import { PrivateBadge } from './PrivateBadge';
 import { PresenceIndicator } from '@/components/PresenceIndicator';
 import { usePoke } from './hooks/usePoke';
+import { useFederatedFollowSync } from './hooks/useFederatedFollowSync';
 import type {
   ProfileHeaderDefaultProps,
   ProfileHeaderMinimalistProps,
@@ -39,6 +40,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
 }: ProfileHeaderDefaultProps) {
   const { t } = useTranslation();
   const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || !!isFederated);
+  useFederatedFollowSync(profileId, isFederated, actorUri);
 
   return (
     <View className="flex-row justify-between items-end mb-2.5" style={{ marginTop: -45 }}>
@@ -187,6 +189,7 @@ export const ProfileHeaderMinimalist = memo(function ProfileHeaderMinimalist({
 export const ProfileActions = memo(function ProfileActions({
   isOwnProfile,
   isFederated,
+  actorUri,
   currentUsername,
   profileUsername,
   profileId,
@@ -195,6 +198,7 @@ export const ProfileActions = memo(function ProfileActions({
 }: {
   isOwnProfile: boolean;
   isFederated?: boolean;
+  actorUri?: string;
   currentUsername?: string;
   profileUsername?: string;
   profileId?: string;
@@ -204,6 +208,7 @@ export const ProfileActions = memo(function ProfileActions({
   const theme = useTheme();
   const { t } = useTranslation();
   const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || !!isFederated);
+  useFederatedFollowSync(profileId, isFederated, actorUri);
 
   if (!isOwnProfile || currentUsername !== profileUsername) {
     if (!profileId) return null;

--- a/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
+++ b/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { useFollow } from '@oxyhq/services';
+import { feedService } from '@/services/feedService';
+
+/**
+ * Watches the Oxy follow state for a federated profile and bridges it
+ * to the ActivityPub layer by calling the federation follow/unfollow
+ * endpoints when the local follow state transitions.
+ *
+ * This hook is a no-op when `isFederated` is false or `actorUri` is absent.
+ */
+export function useFederatedFollowSync(
+  profileId: string | undefined,
+  isFederated: boolean | undefined,
+  actorUri: string | undefined,
+) {
+  const oxyUserId = isFederated && profileId ? profileId : '';
+  const { isFollowing } = useFollow(oxyUserId);
+
+  const settledRef = useRef(false);
+  const prevFollowingRef = useRef(isFollowing);
+
+  useEffect(() => {
+    if (!isFederated || !actorUri || !profileId) return;
+
+    // Skip the first value — it's the initial hydration from the store,
+    // not a user-initiated transition.
+    if (!settledRef.current) {
+      settledRef.current = true;
+      prevFollowingRef.current = isFollowing;
+      return;
+    }
+
+    const wasFollowing = prevFollowingRef.current;
+    prevFollowingRef.current = isFollowing;
+
+    if (wasFollowing === isFollowing) return;
+
+    if (isFollowing) {
+      feedService.followFederatedActor(actorUri).catch(err => {
+        console.warn('[Federation] Failed to send AP Follow:', err);
+      });
+    } else {
+      feedService.unfollowFederatedActor(actorUri).catch(err => {
+        console.warn('[Federation] Failed to send AP Unfollow:', err);
+      });
+    }
+  }, [isFederated, actorUri, profileId, isFollowing]);
+}

--- a/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
+++ b/packages/frontend/components/Profile/hooks/useFederatedFollowSync.ts
@@ -19,6 +19,14 @@ export function useFederatedFollowSync(
 
   const settledRef = useRef(false);
   const prevFollowingRef = useRef(isFollowing);
+  const prevProfileIdRef = useRef(profileId);
+
+  // Reset tracking when the profile changes (component reused via dynamic route)
+  if (prevProfileIdRef.current !== profileId) {
+    prevProfileIdRef.current = profileId;
+    settledRef.current = false;
+    prevFollowingRef.current = isFollowing;
+  }
 
   useEffect(() => {
     if (!isFederated || !actorUri || !profileId) return;
@@ -29,6 +37,7 @@ export function useFederatedFollowSync(
       settledRef.current = true;
       prevFollowingRef.current = isFollowing;
       return;
+    }
     }
 
     const wasFollowing = prevFollowingRef.current;

--- a/packages/frontend/hooks/useProfileData.ts
+++ b/packages/frontend/hooks/useProfileData.ts
@@ -169,15 +169,10 @@ export function useProfileData(username?: string): {
   loading: boolean;
   error: boolean;
 } {
-  const isFederated = Boolean(username && isFederatedUsername(username));
-
-  // Federated path
-  const fedResult = useFederatedProfileData(isFederated ? username! : '');
-
-  // Local path
-  const localResult = useLocalProfileData(isFederated ? undefined : username);
-
-  return isFederated ? fedResult : localResult;
+  // All profiles (local and federated) use the same code path.
+  // The OxyHQ API resolves federated handles (user@domain) transparently
+  // via WebFinger when they're not yet in the local DB.
+  return useLocalProfileData(username);
 }
 
 /**
@@ -254,12 +249,19 @@ function useLocalProfileData(username?: string): {
 
     const design = computeDesign(oxyProfile, appearance);
 
+    const federation = oxyProfile.federation as { actorUri?: string; domain?: string } | undefined;
+
     return {
       ...oxyProfile,
       id: oxyProfile.id || '',
       username: oxyProfile.username || '',
       postsCount: appearance?.postsCount,
       followsYou: appearance?.followsYou,
+      isFederated: oxyProfile.isFederated || oxyProfile.type === 'federated',
+      actorUri: oxyProfile.actorUri || federation?.actorUri,
+      instance: oxyProfile.instance || federation?.domain,
+      followersCount: oxyProfile._count?.followers ?? oxyProfile.followersCount ?? 0,
+      followingCount: oxyProfile._count?.following ?? oxyProfile.followingCount ?? 0,
       design,
       privacy: appearance?.privacy,
     };

--- a/packages/frontend/services/feedService.ts
+++ b/packages/frontend/services/feedService.ts
@@ -584,6 +584,26 @@ class FeedService {
       // Non-critical — swallow errors
     }
   }
+
+  // ────────────────────────────────────────────────────────────
+  // Federation — ActivityPub follow/unfollow
+  // ────────────────────────────────────────────────────────────
+
+  /**
+   * Send an ActivityPub Follow activity to a remote federated actor.
+   */
+  async followFederatedActor(actorUri: string): Promise<{ success: boolean; pending: boolean }> {
+    const response = await authenticatedClient.post('/federation/follow', { actorUri });
+    return response.data;
+  }
+
+  /**
+   * Send an ActivityPub Undo(Follow) activity to a remote federated actor.
+   */
+  async unfollowFederatedActor(actorUri: string): Promise<{ success: boolean }> {
+    const response = await authenticatedClient.post('/federation/unfollow', { actorUri });
+    return response.data;
+  }
 }
 
 export const feedService = new FeedService(); 


### PR DESCRIPTION
## Summary

- **Fix Accept handling**: `handleAccept` now processes Accept activities where `object` is a string reference (not just embedded Follow objects). Many servers (e.g. Threads) send Accept with just the Follow activity ID as a string — these were silently ignored, leaving follows stuck as `pending` forever.
- **Fix actor URI mismatch**: `sendFollow` now uses the canonical actor URI from the fetched actor (not the original parameter), preventing mismatches when the Accept comes back signed with the canonical URI.
- **Trigger outbox sync on accept**: After a follow is accepted, the newly followed actor's outbox is synced to backfill their recent posts.
- **Bridge Oxy follow with AP Follow**: New `useFederatedFollowSync` hook detects when a user follows/unfollows a federated profile via the FollowButton and fires the corresponding ActivityPub Follow/Undo(Follow) via Mention's federation API.
- **Merge federated followingIds into feed**: The feed controller now includes oxyUserIds from accepted `FederatedFollow` records in the `followingIds` list, ensuring posts from AP-followed users appear in Following and ForYou feeds.

## Test plan

- [ ] Follow a fediverse user (e.g. @user@mastodon.social) — verify AP Follow is sent (check backend logs for delivery)
- [ ] Verify the follow Accept is processed (FederatedFollow status becomes `accepted`)
- [ ] Check the user's profile tab shows their posts (outbox sync triggered)
- [ ] Verify posts appear in the Following feed
- [ ] Unfollow the user — verify AP Undo(Follow) is sent
- [ ] Run backend tests: `cd packages/backend && bun run test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
