### PR TITLE
fix: resolve post action integration bugs

### DIFF
--- a/packages/frontend/components/Post/PostActionsWithNotifications.tsx
+++ b/packages/frontend/components/Post/PostActionsWithNotifications.tsx
@@ -39,26 +39,24 @@ const PostActionsWithNotifications: React.FC<Props> = ({
     const { notifyLike, notifyRepost } = useNotificationActions();
 
     const handleLike = async () => {
+        onLike();
         try {
-            onLike();
             if (!isLiked) {
                 await notifyLike(postId, postAuthorId);
             }
         } catch (error) {
-            logger.error('Error handling like with notification');
-            onLike();
+            logger.error('Error sending like notification');
         }
     };
 
     const handleRepost = async () => {
+        onRepost();
         try {
-            onRepost();
             if (!isReposted) {
                 await notifyRepost(postId, postAuthorId);
             }
         } catch (error) {
-            logger.error('Error handling repost with notification');
-            onRepost();
+            logger.error('Error sending repost notification');
         }
     };
 

--- a/packages/frontend/hooks/usePostSubmission.ts
+++ b/packages/frontend/hooks/usePostSubmission.ts
@@ -90,7 +90,7 @@ export const usePostSubmission = ({
     const hasPoll = pollOptions.length > 0 && pollOptions.some(opt => opt.trim().length > 0);
     
     return hasText || hasMedia || hasPoll || hasArticleContent || hasEventContent;
-  }, [postContent, mediaIds, pollOptions, hasArticleContent]);
+  }, [postContent, mediaIds, pollOptions, hasArticleContent, hasEventContent]);
 
   const buildMainPost = useCallback(() => {
     const formattedSources = sanitizeSourcesForSubmit(sources);
@@ -171,6 +171,8 @@ export const usePostSubmission = ({
     pollOptions,
     article,
     hasArticleContent,
+    event,
+    hasEventContent,
     location,
     sources,
     attachmentOrder,

--- a/packages/frontend/services/echoGuard.ts
+++ b/packages/frontend/services/echoGuard.ts
@@ -1,6 +1,6 @@
 // A tiny shared echo guard to suppress socket echo updates after local actions
 
-type EchoAction = "like" | "unlike" | "repost" | "unrepost" | "save" | "unsave" | "reply";
+type EchoAction = "like" | "unlike" | "downvote" | "repost" | "unrepost" | "save" | "unsave" | "reply";
 
 const recentActions: Map<string, Record<EchoAction, number>> = new Map();
 

--- a/packages/frontend/services/socketService.ts
+++ b/packages/frontend/services/socketService.ts
@@ -5,7 +5,7 @@ import { AppState, type AppStateStatus } from 'react-native';
 import { io, Socket } from 'socket.io-client';
 import { usePostsStore } from '../stores/postsStore';
 import { createScopedLogger } from '@/lib/logger';
-import { wasRecent } from './echoGuard';
+import { wasRecent, type EchoAction } from './echoGuard';
 
 const logger = createScopedLogger('SocketService');
 
@@ -153,7 +153,7 @@ class SocketService {
     // If server includes actor identity and it's us, ignore
     if (actorId && this.currentUserId && actorId === this.currentUserId) return true;
     // Otherwise, ignore if we performed the same action very recently
-    return wasRecent(postId, action as any);
+    return wasRecent(postId, action as EchoAction);
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Fix double-toggle bug** in `PostActionsWithNotifications`: error handlers were calling `onLike()`/`onRepost()` a second time, undoing the original action. Now the action fires unconditionally and notifications are fire-and-forget.
- **Add missing `"downvote"` to `EchoAction` type** in `echoGuard.ts`: the postsStore was calling `markLocalAction(postId, 'downvote')` but the type didn't include it, causing a type mismatch and `as any` cast in socketService.
- **Fix stale closures in `usePostSubmission`**: `validatePost` was missing `hasEventContent` in its dependency array, and `buildMainPost` was missing `event` and `hasEventContent`, causing event-only posts to fail validation or use stale event data.
- **Remove `as any` cast** in `socketService.ts`, replacing with proper `as EchoAction` import.

## Test plan
- [ ] Create a post with only event content (no text) — should pass validation
- [ ] Like/unlike posts — verify no double-toggle on notification failure
- [ ] Downvote a post — verify socket echo is properly suppressed
- [ ] TypeScript compiles without new errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
