### PR TITLE
fix: align notification pagination with backend cursor API

### DIFF
--- a/packages/frontend/hooks/useRealtimeNotifications.ts
+++ b/packages/frontend/hooks/useRealtimeNotifications.ts
@@ -106,7 +106,7 @@ export const useRealtimeNotifications = () => {
     return () => {
       disconnectSocket();
     };
-  }, [isAuthenticated, user?.id, connectSocket, disconnectSocket]);
+  }, [isAuthenticated, isReady, user?.id, connectSocket, disconnectSocket]);
 
   return {
     isConnected: socket?.connected || false,

--- a/packages/frontend/services/notificationService.ts
+++ b/packages/frontend/services/notificationService.ts
@@ -8,7 +8,7 @@ interface NotificationsResponse {
     notifications: Notification[];
     unreadCount: number;
     hasMore: boolean;
-    page: number;
+    nextCursor?: string;
     limit: number;
 }
 
@@ -21,8 +21,7 @@ class NotificationService {
             const params: any = { limit };
 
             if (cursor) {
-                // For pagination, use page parameter if cursor represents page number
-                params.page = parseInt(cursor) || 1;
+                params.cursor = cursor;
             }
 
             const response = await authenticatedClient.get('/notifications', { params });
@@ -31,7 +30,7 @@ class NotificationService {
                 notifications: response.data.notifications || [],
                 unreadCount: response.data.unreadCount || 0,
                 hasMore: response.data.hasMore || false,
-                page: response.data.page || 1,
+                nextCursor: response.data.nextCursor,
                 limit: response.data.limit || limit,
             };
         } catch (error) {


### PR DESCRIPTION
## Summary
- **Fixed pagination mismatch**: The backend uses cursor-based pagination (`cursor` param expecting an ObjectId string, returning `nextCursor`), but the frontend `notificationService` was sending a `page` number parameter. Updated to send `cursor` and read `nextCursor` from the response.
- **Fixed missing React hook dependency**: Added `isReady` to the `useEffect` dependency array in `useRealtimeNotifications`, since the effect's condition checks `isReady` but it was missing from deps.
- **Reviewed all notification system files** (notifications screen, NotificationItem, GroupedNotificationItem, permission components, RegisterPushToken, notificationCreationService, useNotificationActions) — all other backend endpoint paths (`/notifications`, `/notifications/:id/read`, `/notifications/read-all`, `/notifications/unread-count`, `/notifications/push-token`) match correctly.

## Test plan
- [ ] Verify notifications load on the notifications screen
- [ ] Verify mark-as-read and mark-all-as-read work
- [ ] Verify real-time socket notifications arrive after the `isReady` fix
- [ ] Verify push token registration on native builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
