### PR TITLE
fix: remove unnecessary isFederated guards from profile components

### DIFF
--- a/packages/frontend/components/Profile/ProfileHeader.tsx
+++ b/packages/frontend/components/Profile/ProfileHeader.tsx
@@ -39,7 +39,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
   showBottomSheet,
 }: ProfileHeaderDefaultProps) {
   const { t } = useTranslation();
-  const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || !!isFederated);
+  const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile);
   useFederatedFollowSync(profileId, isFederated, actorUri);
 
   return (
@@ -58,7 +58,7 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
           }}
           imageStyle={{}}
         />
-        {!isOwnProfile && !isFederated && profileId && (
+        {!isOwnProfile && profileId && (
           <PresenceIndicator
             userId={profileId}
             size="medium"
@@ -99,20 +99,18 @@ export const ProfileHeaderDefault = memo(function ProfileHeaderDefault({
           </View>
         ) : profileId ? (
           <View className="flex-row items-center gap-3">
-            {!isFederated && (
-              <TouchableOpacity
-                className={cn(
-                  'w-10 h-10 rounded-full border items-center justify-center',
-                  poked ? 'bg-primary border-primary' : 'bg-background border-border',
-                )}
-                onPress={togglePoke}
-                disabled={pokeLoading}
-                accessibilityRole="button"
-                accessibilityLabel={poked ? 'Unpoke' : 'Poke'}
-              >
-                <Ionicons name={poked ? 'hand-left' : 'hand-left-outline'} size={20} color={poked ? '#fff' : theme.colors.text} />
-              </TouchableOpacity>
-            )}
+            <TouchableOpacity
+              className={cn(
+                'w-10 h-10 rounded-full border items-center justify-center',
+                poked ? 'bg-primary border-primary' : 'bg-background border-border',
+              )}
+              onPress={togglePoke}
+              disabled={pokeLoading}
+              accessibilityRole="button"
+              accessibilityLabel={poked ? 'Unpoke' : 'Poke'}
+            >
+              <Ionicons name={poked ? 'hand-left' : 'hand-left-outline'} size={20} color={poked ? '#fff' : theme.colors.text} />
+            </TouchableOpacity>
             <FollowButtonComponent userId={profileId} />
           </View>
         ) : null}
@@ -207,27 +205,25 @@ export const ProfileActions = memo(function ProfileActions({
 }) {
   const theme = useTheme();
   const { t } = useTranslation();
-  const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile || !!isFederated);
+  const { poked, loading: pokeLoading, toggle: togglePoke } = usePoke(profileId, isOwnProfile);
   useFederatedFollowSync(profileId, isFederated, actorUri);
 
   if (!isOwnProfile || currentUsername !== profileUsername) {
     if (!profileId) return null;
     return (
       <View className="flex-row items-center gap-3">
-        {!isFederated && (
-          <TouchableOpacity
-            className={cn(
-              'w-10 h-10 rounded-full border items-center justify-center',
-              poked ? 'bg-primary border-primary' : 'bg-background border-border',
-            )}
-            onPress={togglePoke}
-            disabled={pokeLoading}
-            accessibilityRole="button"
-            accessibilityLabel={poked ? 'Unpoke' : 'Poke'}
-          >
-            <Ionicons name={poked ? 'hand-left' : 'hand-left-outline'} size={20} color={poked ? '#fff' : theme.colors.text} />
-          </TouchableOpacity>
-        )}
+        <TouchableOpacity
+          className={cn(
+            'w-10 h-10 rounded-full border items-center justify-center',
+            poked ? 'bg-primary border-primary' : 'bg-background border-border',
+          )}
+          onPress={togglePoke}
+          disabled={pokeLoading}
+          accessibilityRole="button"
+          accessibilityLabel={poked ? 'Unpoke' : 'Poke'}
+        >
+          <Ionicons name={poked ? 'hand-left' : 'hand-left-outline'} size={20} color={poked ? '#fff' : theme.colors.text} />
+        </TouchableOpacity>
         <FollowButtonComponent userId={profileId} />
       </View>
     );

--- a/packages/frontend/components/Profile/ProfileTabs.tsx
+++ b/packages/frontend/components/Profile/ProfileTabs.tsx
@@ -30,16 +30,15 @@ export const ProfileTabs = memo(function ProfileTabs({
   profileId,
   isPrivate,
   isOwnProfile,
-  isFederated,
   actorUri,
 }: ProfileTabsProps) {
   const theme = useTheme();
   const { t } = useTranslation();
   const [pinnedPost, setPinnedPost] = useState<any>(null);
 
-  // Fetch pinned post once per profile (local profiles only)
+  // Fetch pinned post once per profile
   useEffect(() => {
-    if (isFederated || !profileId || (isPrivate && !isOwnProfile)) {
+    if (!profileId || (isPrivate && !isOwnProfile)) {
       setPinnedPost(null);
       return;
     }
@@ -53,7 +52,7 @@ export const ProfileTabs = memo(function ProfileTabs({
       });
 
     return () => { cancelled = true; };
-  }, [profileId, isPrivate, isOwnProfile, isFederated]);
+  }, [profileId, isPrivate, isOwnProfile]);
 
   // Don't render feed content without a valid profile identifier
   if (!profileId && !actorUri) {
@@ -80,8 +79,8 @@ export const ProfileTabs = memo(function ProfileTabs({
     );
   }
 
-  // Starter Packs tab (local profiles only)
-  if (tab === 'starter_packs' && !isFederated) {
+  // Starter Packs tab
+  if (tab === 'starter_packs') {
     return (
       <ProfileStarterPacks
         profileId={profileId}
@@ -90,8 +89,8 @@ export const ProfileTabs = memo(function ProfileTabs({
     );
   }
 
-  // Lists tab (local profiles only)
-  if (tab === 'lists' && !isFederated) {
+  // Lists tab
+  if (tab === 'lists') {
     return (
       <ProfileLists
         profileId={profileId}
@@ -100,8 +99,8 @@ export const ProfileTabs = memo(function ProfileTabs({
     );
   }
 
-  // Feeds tab (local profiles only)
-  if (tab === 'feeds' && !isFederated) {
+  // Feeds tab
+  if (tab === 'feeds') {
     return (
       <ProfileFeeds
         profileId={profileId}
@@ -110,8 +109,8 @@ export const ProfileTabs = memo(function ProfileTabs({
     );
   }
 
-  // Media grid (local profiles only)
-  if (tab === 'media' && !isFederated) {
+  // Media grid
+  if (tab === 'media') {
     return (
       <MediaGrid
         userId={profileId}
@@ -121,8 +120,8 @@ export const ProfileTabs = memo(function ProfileTabs({
     );
   }
 
-  // Videos grid (local profiles only)
-  if (tab === 'videos' && !isFederated) {
+  // Videos grid
+  if (tab === 'videos') {
     return (
       <VideosGrid
         userId={profileId}
@@ -135,14 +134,14 @@ export const ProfileTabs = memo(function ProfileTabs({
   // Unified feed for posts, replies, likes, reposts — works for both native and federated
   return (
     <View>
-      {/* Pinned post - only show on posts tab for local profiles */}
-      {!isFederated && tab === 'posts' && pinnedPost && (
+      {/* Pinned post - only show on posts tab */}
+      {tab === 'posts' && pinnedPost && (
         <React.Suspense fallback={null}>
           <PinnedPostItem post={pinnedPost} showPinned />
         </React.Suspense>
       )}
       <Feed
-        type={(isFederated ? 'posts' : tab) as FeedType}
+        type={tab as FeedType}
         userId={profileId}
         hideHeader={true}
         scrollEnabled={false}

--- a/packages/frontend/components/ProfileScreen.tsx
+++ b/packages/frontend/components/ProfileScreen.tsx
@@ -122,11 +122,11 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
         currentTab: tab,
     });
 
-    // Follow data — skip useFollow for federated profiles (uses data from profileData)
-    const stableUserId = isFederated ? '' : (profileData?.id || '');
-    const { followerCount: localFollowerCount = 0, followingCount: localFollowingCount = 0, isFollowing: isFollowingProfileUser = false } = useFollow(stableUserId);
-    const followerCount = isFederated ? (profileData?.followersCount ?? 0) : localFollowerCount;
-    const followingCount = isFederated ? (profileData?.followingCount ?? 0) : localFollowingCount;
+    // Follow data — federated users are stored in Oxy, so useFollow works with their Oxy ID
+    const stableUserId = profileData?.id || '';
+    const { followerCount: rawFollowerCount, followingCount: rawFollowingCount, isFollowing: isFollowingProfileUser = false } = useFollow(stableUserId);
+    const followerCount = rawFollowerCount ?? 0;
+    const followingCount = rawFollowingCount ?? 0;
 
     // Track "just followed" — show suggestions only on the follow action, not on revisits
     const [justFollowed, setJustFollowed] = useState(false);
@@ -155,11 +155,11 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
         prevFollowRef.current = isFollowingProfileUser;
     }
 
-    // Subscription handling — disabled for federated profiles
+    // Subscription handling
     const { subscribed, loading: subLoading, toggle: toggleSubscription } = useSubscription(
-        isFederated ? undefined : profileData?.id,
+        profileData?.id,
         currentUser?.id,
-        isFederated || currentUser?.id === profileData?.id
+        currentUser?.id === profileData?.id
     );
 
     // Computed values
@@ -202,22 +202,20 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
         [profileData]
     );
 
-    // Tabs — federated profiles only show Posts
+    // Tabs — all users (including federated) get full tabs since data is in Oxy/Mention DB
     const tabs = useMemo(
-        () => isFederated
-            ? [t('profile.tabs.posts')]
-            : [
-                t('profile.tabs.posts'),
-                t('profile.tabs.replies'),
-                t('profile.tabs.media'),
-                t('profile.tabs.videos'),
-                t('profile.tabs.likes'),
-                t('profile.tabs.reposts'),
-                t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
-                t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
-                t('profile.tabs.lists', { defaultValue: 'Lists' }),
-            ],
-        [t, isFederated]
+        () => [
+            t('profile.tabs.posts'),
+            t('profile.tabs.replies'),
+            t('profile.tabs.media'),
+            t('profile.tabs.videos'),
+            t('profile.tabs.likes'),
+            t('profile.tabs.reposts'),
+            t('profile.tabs.feeds', { defaultValue: 'Feeds' }),
+            t('profile.tabs.starter_packs', { defaultValue: 'Starter Packs' }),
+            t('profile.tabs.lists', { defaultValue: 'Lists' }),
+        ],
+        [t]
     );
 
     // Clear cached feed data for private profiles
@@ -234,13 +232,11 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
     const onTabPress = useCallback(
         (index: number) => {
             if (!username) return;
-            // Federated profiles only have 1 tab
-            if (isFederated) return;
             const tabName = TAB_NAMES[index];
             const path = index === 0 ? `/@${username}` : `/@${username}/${tabName}`;
             router.push(path as any);
         },
-        [username, isFederated]
+        [username]
     );
 
     const handlePostsPress = useCallback(() => {
@@ -454,7 +450,7 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
                     <>
                         {/* Header actions */}
                         <View className="absolute flex-row items-center" style={[{ zIndex: 10, right: LAYOUT.DEFAULT_PADDING, gap: 8 }, themedStyles.headerActions]}>
-                            {!isOwnProfile && !isFederated && (
+                            {!isOwnProfile && (
                                 <IconButton variant="icon" onPress={toggleSubscription} disabled={subLoading}>
                                     {subscribed ? (
                                         <BellActive size={20} className="text-primary" />
@@ -463,7 +459,7 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
                                     )}
                                 </IconButton>
                             )}
-                            {!isOwnProfile && !isFederated && (
+                            {!isOwnProfile && (
                                 <IconButton variant="icon" onPress={handleDM}>
                                     <Ionicons name="mail-outline" size={20} color={theme.colors.text} />
                                 </IconButton>
@@ -476,7 +472,7 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
                             <IconButton variant="icon" onPress={handleShare}>
                                 <ShareIcon size={20} className="text-foreground" />
                             </IconButton>
-                            {!isOwnProfile && !isFederated && (
+                            {!isOwnProfile && (
                                 <IconButton variant="icon" onPress={handleMoreOptions}>
                                     <Ionicons name="ellipsis-horizontal" size={20} color={theme.colors.text} />
                                 </IconButton>
@@ -583,7 +579,7 @@ const MentionProfile: React.FC<ProfileScreenProps> = ({ tab = 'posts' }) => {
                                         onLayout={setProfileContentHeight}
                                     />
                                 )}
-                                {!isOwnProfile && !isFederated && profileData?.id && (
+                                {!isOwnProfile && profileData?.id && (
                                     <SuggestedUsers
                                         visible={justFollowed}
                                         sourceUserId={profileData.id}


### PR DESCRIPTION
## Summary
- Removed `!isFederated` guards that unnecessarily disabled mute, block, report, DM, subscription bell, poke, presence indicator, and more-options menu for federated users
- Enabled all profile tabs (replies, media, videos, likes, reposts, feeds, starter packs, lists) for federated users instead of restricting to posts-only
- Removed `isFederated` guard on `useFollow` hook so follow counts come from local Oxy data for all users
- Kept `isFederated` only where appropriate: fediverse badge icon, "open on instance" button, cover image URL resolution, and federated follow sync

## Test plan
- [ ] Visit a federated user profile and verify all tabs (posts, replies, media, etc.) are visible and functional
- [ ] Verify mute/block/report/DM/subscription bell appear on federated user profiles
- [ ] Verify poke button works on federated user profiles
- [ ] Verify presence indicator shows on federated user profiles
- [ ] Verify follow/follower counts display correctly for federated users
- [ ] Verify "open on instance" button still appears for federated users
- [ ] Verify fediverse badge still shows on federated user names
- [ ] Verify native (non-federated) user profiles are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
