### PR TITLE
fix: sync federated actor profiles to Oxy, query posts by oxyUserId

### DIFF
--- a/packages/backend/src/routes/federation.api.routes.ts
+++ b/packages/backend/src/routes/federation.api.routes.ts
@@ -201,11 +201,11 @@ router.get('/actor/posts', async (req: AuthRequest, res: Response) => {
     if (!actor) return res.json({ posts: [], hasMore: false });
 
     const limit = 20;
-    // AP activity IDs are namespaced under the actor URI (e.g. https://instance/users/alice/statuses/123)
-    // Use a range query so the B-tree index on federation.activityId is used (regex can't use it)
-    const query: Record<string, unknown> = {
-      'federation.activityId': { $gte: actor.uri + '/', $lt: actor.uri + '/\uffff' },
-    };
+    // Query by oxyUserId (the canonical user identity in Oxy) for federated posts.
+    // Falls back to the activity ID range query if the actor has no Oxy link yet.
+    const query: Record<string, unknown> = actor.oxyUserId
+      ? { oxyUserId: actor.oxyUserId, federation: { $ne: null } }
+      : { 'federation.activityId': { $gte: actor.uri + '/', $lt: actor.uri + '/\uffff' } };
     if (parsed.data.cursor) {
       query.createdAt = { $lt: new Date(parsed.data.cursor) };
     }

--- a/packages/backend/src/services/FederationJobScheduler.ts
+++ b/packages/backend/src/services/FederationJobScheduler.ts
@@ -145,7 +145,7 @@ class FederationJobScheduler {
         uri: { $in: followedActorUris },
         outboxUrl: { $ne: null },
       })
-        .select('uri acct outboxUrl')
+        .select('uri acct outboxUrl oxyUserId')
         .lean();
 
       if (actors.length === 0) return;

--- a/packages/backend/src/services/FederationService.ts
+++ b/packages/backend/src/services/FederationService.ts
@@ -253,9 +253,9 @@ class FederationService {
         { upsert: true, returnDocument: 'after', lean: true },
       );
 
-      // Resolve to Oxy User if not already linked.
-      // Also retries on stale refresh if a previous resolution failed.
-      if (fedActor && !fedActor.oxyUserId) {
+      // Always upsert into Oxy so profile changes (avatar, name, bio) are synced.
+      // resolveExternalUser creates the user if not exists, updates if changed.
+      if (fedActor) {
         try {
           const oxyClient = getServiceOxyClient();
           const oxyUser = await oxyClient.resolveExternalUser({
@@ -267,7 +267,7 @@ class FederationService {
             avatar: actor.icon?.url || actor.icon?.href,
             bio: actor.summary ? htmlToPlainText(actor.summary) : undefined,
           });
-          if (oxyUser?.id) {
+          if (oxyUser?.id && fedActor.oxyUserId !== String(oxyUser.id)) {
             await FederatedActor.updateOne({ _id: fedActor._id }, { $set: { oxyUserId: String(oxyUser.id) } });
           }
         } catch (resolveErr) {
@@ -1021,8 +1021,7 @@ class FederationService {
 
     const post = await Post.findOne({ 'federation.activityId': objectId, federation: { $ne: null } }).lean();
     if (!post) return;
-    // Verify the deleting actor owns this post
-    const postActorUri = this.extractActorUri((post.federation as any)?.activityId ? actorUri : undefined);
+    // Verify the deleting actor owns this post via Oxy user ID
     const actorRecord = await FederatedActor.findOne({ uri: actorUri }).lean();
     if (actorRecord && post.oxyUserId && actorRecord.oxyUserId !== post.oxyUserId) {
       logger.warn(`Delete rejected: actor ${actorUri} does not own post ${objectId}`);


### PR DESCRIPTION
## Summary
- **Always upsert federated actors into Oxy** via `resolveExternalUser` on every fetch, not just the first time. This ensures avatar, display name, and bio changes from remote instances are reflected in Oxy.
- **Query actor posts by `oxyUserId`** instead of a fragile `federation.activityId` range query, with fallback for actors not yet linked to Oxy.
- **Include `oxyUserId` in job scheduler's actor select** so `syncOutboxPosts` doesn't trigger unnecessary actor re-resolution.
- **Remove dead code** in `handleDelete` (unused `postActorUri` variable).

## Test plan
- [ ] Verify that following a new remote actor creates an Oxy user with `isFederated: true`
- [ ] Verify that re-fetching an existing actor (e.g. stale refresh) updates the Oxy profile if name/avatar changed
- [ ] Verify that `/federation/actor/posts?uri=...` returns posts for actors with an `oxyUserId`
- [ ] Verify outbox sync job passes `oxyUserId` to `syncOutboxPosts` avoiding extra actor lookups
- [ ] Verify hydrated federated posts show `isFederated: true` and the fediverse icon in the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
