### PR TITLE
fix: clean up rooms, insights, and statistics frontend

### DIFF
--- a/packages/frontend/app/(app)/agora/[id].tsx
+++ b/packages/frontend/app/(app)/agora/[id].tsx
@@ -35,7 +35,6 @@ import { logger } from '@/lib/logger';
 const ParticipantAvatar = ({ userId, oxyServices }: { userId: string; oxyServices: any }) => {
   const profile = useUserById(userId);
   const avatarUri = getAvatarUrl(profile, oxyServices);
-  const displayName = getDisplayName(profile, userId);
   return <Avatar size={32} source={avatarUri} shape="squircle"  placeholderIcon={<MentionAvatarIcon size={32 * 0.6} />} />;
 };
 
@@ -86,7 +85,7 @@ const RoomDetailScreen = () => {
     } finally {
       setLoading(false);
     }
-  }, [id]);
+  }, [id, user?.id]);
 
   useEffect(() => {
     loadRoom();
@@ -135,7 +134,7 @@ const RoomDetailScreen = () => {
   };
 
   // Resolve user IDs to real profiles (must be before conditional return for hooks rules)
-  const allUserIds = [room?.host, ...(room?.participants || []), ...(room?.speakers || [])].filter(Boolean);
+  const allUserIds = [room?.host, ...(room?.participants || []), ...(room?.speakers || [])].filter((id): id is string => Boolean(id));
   useRoomUsers(allUserIds);
 
   const isLive = room?.status === 'live';

--- a/packages/frontend/app/(app)/insights.tsx
+++ b/packages/frontend/app/(app)/insights.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
     View,
     Text,
@@ -8,7 +8,6 @@ import {
     Platform
 } from 'react-native';
 import { Loading } from '@oxyhq/bloom/loading';
-import Animated, { useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { useSafeBack } from '@/hooks/useSafeBack';
@@ -155,7 +154,7 @@ const InsightsScreen: React.FC = () => {
 
     useEffect(() => {
         loadStatistics();
-    }, [selectedPeriod]);
+    }, [loadStatistics]);
 
     const handlePeriodChange = useCallback((val: number) => {
         if (val !== selectedPeriod) setSelectedPeriod(val);

--- a/packages/frontend/app/(app)/statistics.tsx
+++ b/packages/frontend/app/(app)/statistics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
     View,
     Text,
@@ -6,7 +6,6 @@ import {
     ScrollView,
     TouchableOpacity,
     Dimensions,
-    Platform
 } from 'react-native';
 import { Loading } from '@oxyhq/bloom/loading';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';

--- a/packages/frontend/components/insights/SectionHeader.tsx
+++ b/packages/frontend/components/insights/SectionHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 
 interface SectionHeaderProps {
     icon?: string;
@@ -9,11 +10,21 @@ interface SectionHeaderProps {
 }
 
 const SectionHeader: React.FC<SectionHeaderProps> = ({
+    icon,
     title,
+    iconColor,
     titleColor,
 }) => {
     return (
         <View className="flex-row items-center mb-3">
+            {icon && (
+                <Ionicons
+                    name={icon as any}
+                    size={20}
+                    color={iconColor}
+                    style={{ marginRight: 8 }}
+                />
+            )}
             <Text
                 className="text-foreground text-lg font-bold"
                 style={titleColor ? { color: titleColor } : undefined}

--- a/packages/frontend/components/insights/SectionHeader.tsx
+++ b/packages/frontend/components/insights/SectionHeader.tsx
@@ -19,7 +19,7 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
         <View className="flex-row items-center mb-3">
             {icon && (
                 <Ionicons
-                    name={icon as any}
+                    name={icon as React.ComponentProps<typeof Ionicons>['name']}
                     size={20}
                     color={iconColor}
                     style={{ marginRight: 8 }}


### PR DESCRIPTION
## Summary
- Remove unused imports (`useMemo`, `Animated`, `useAnimatedStyle`, `withSpring`, `Platform`) from insights.tsx and statistics.tsx
- Fix missing `user?.id` dependency in `loadRoom` useCallback in agora/[id].tsx, which could cause stale `isJoined` state
- Fix insights.tsx useEffect depending on `selectedPeriod` instead of `loadStatistics` callback (violates exhaustive-deps rule)
- Remove unused `displayName` variable in `ParticipantAvatar` component
- Wire up declared-but-ignored `icon`/`iconColor` props in `SectionHeader` component
- Fix pre-existing TypeScript error: use type-narrowing `filter()` predicate instead of `filter(Boolean)`

## Test plan
- [ ] Verify agora room listing loads correctly
- [ ] Verify room detail page shows correct join status
- [ ] Verify insights page loads and period switching works
- [ ] Verify statistics page loads without errors
- [ ] Verify `npx tsc --noEmit` passes for all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
