### PR TITLE
fix: prevent privacy settings from overwriting each other on save

### DIFF
--- a/packages/frontend/app/(app)/settings/feed.tsx
+++ b/packages/frontend/app/(app)/settings/feed.tsx
@@ -10,28 +10,13 @@ import { useSafeBack } from '@/hooks/useSafeBack';
 import { ThemedView } from '@/components/ThemedView';
 import { Toggle } from '@/components/Toggle';
 import { Slider } from '@/components/Slider';
-import { useFeedSettings, FeedSettings } from '@/hooks/useFeedSettings';
+import { useFeedSettings, DEFAULT_FEED_SETTINGS, type FeedSettings } from '@/hooks/useFeedSettings';
 import { useTranslation } from 'react-i18next';
 import { Ionicons } from '@expo/vector-icons';
 import { SettingsItem, SettingsGroup } from '@/components/settings/SettingsItem';
 import { logger } from '@/lib/logger';
 
 const IconComponent = Ionicons as React.ComponentType<React.ComponentProps<typeof Ionicons>>;
-
-const DEFAULT_FEED_SETTINGS: FeedSettings = {
-  diversity: {
-    enabled: true,
-    sameAuthorPenalty: 0.95,
-    sameTopicPenalty: 0.92,
-  },
-  recency: {
-    halfLifeHours: 24,
-    maxAgeHours: 168,
-  },
-  quality: {
-    boostHighQuality: true,
-  },
-};
 
 const PRESETS = {
   mostRecent: {

--- a/packages/frontend/app/(app)/settings/privacy.tsx
+++ b/packages/frontend/app/(app)/settings/privacy.tsx
@@ -18,18 +18,7 @@ import {
     getRecommendationFilters,
     saveRecommendationFilters,
 } from '@/lib/recommendationFilters';
-
-interface PrivacySettings {
-    profileVisibility?: 'public' | 'private' | 'followers_only';
-    showContactInfo?: boolean;
-    allowTags?: boolean;
-    allowMentions?: boolean;
-    showOnlineStatus?: boolean;
-    hideLikeCounts?: boolean;
-    hideShareCounts?: boolean;
-    hiddenWords?: string[];
-    restrictedUsers?: string[];
-}
+import type { PrivacySettings } from '@/hooks/usePrivacySettings';
 
 const FILTER_TOGGLES: Array<{
     icon: string;

--- a/packages/frontend/app/(app)/settings/privacy/hide-counts.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/hide-counts.tsx
@@ -53,28 +53,19 @@ export default function HideCountsScreen() {
                 const currentResponse = await authenticatedClient.get('/profile/settings/me');
                 currentPrivacy = currentResponse.data?.privacy || {};
             } catch (e) {
-                // If we can't load current settings, start fresh
                 hideCountsLogger.debug('Could not load current privacy settings', { error: e });
             }
 
-            // Update with merged settings
             const updatedPrivacy = {
                 ...currentPrivacy,
-                [field]: value
+                [field]: value,
             };
             await authenticatedClient.put('/profile/settings', {
-                privacy: updatedPrivacy
+                privacy: updatedPrivacy,
             });
 
-            // Update cache immediately
-            try {
-                const currentResponse = await authenticatedClient.get('/profile/settings/me');
-                if (currentResponse.data?.privacy) {
-                    await updatePrivacySettingsCache(currentResponse.data.privacy);
-                }
-            } catch (e) {
-                hideCountsLogger.debug('Failed to update privacy settings cache', { error: e });
-            }
+            // Update cache from local state to avoid extra GET
+            await updatePrivacySettingsCache(updatedPrivacy);
         } catch (error) {
             hideCountsLogger.error('Error updating setting', { error });
         }
@@ -100,7 +91,7 @@ export default function HideCountsScreen() {
                 hideSaveCounts: value
             };
             await authenticatedClient.put('/profile/settings', {
-                privacy: updatedPrivacy
+                privacy: updatedPrivacy,
             });
 
             // Update local state
@@ -109,15 +100,8 @@ export default function HideCountsScreen() {
             setHideReplyCounts(value);
             setHideSaveCounts(value);
 
-            // Update cache immediately
-            try {
-                const currentResponse = await authenticatedClient.get('/profile/settings/me');
-                if (currentResponse.data?.privacy) {
-                    await updatePrivacySettingsCache(currentResponse.data.privacy);
-                }
-            } catch (e) {
-                hideCountsLogger.debug('Failed to update privacy settings cache', { error: e });
-            }
+            // Update cache from local state to avoid extra GET
+            await updatePrivacySettingsCache(updatedPrivacy);
         } catch (error) {
             hideCountsLogger.error('Error updating all settings', { error });
         }

--- a/packages/frontend/app/(app)/settings/privacy/hide-counts.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/hide-counts.tsx
@@ -68,6 +68,11 @@ export default function HideCountsScreen() {
             await updatePrivacySettingsCache(updatedPrivacy);
         } catch (error) {
             hideCountsLogger.error('Error updating setting', { error });
+            // Revert on failure
+            if (field === 'hideLikeCounts') setHideLikeCounts(!value);
+            if (field === 'hideShareCounts') setHideShareCounts(!value);
+            if (field === 'hideReplyCounts') setHideReplyCounts(!value);
+            if (field === 'hideSaveCounts') setHideSaveCounts(!value);
         }
     };
 

--- a/packages/frontend/app/(app)/settings/privacy/online-status.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/online-status.tsx
@@ -35,13 +35,26 @@ export default function OnlineStatusScreen() {
 
     const updateSetting = async (value: boolean) => {
         try {
+            // Load current settings first to preserve other privacy settings
+            let currentPrivacy = {};
+            try {
+                const currentResponse = await authenticatedClient.get('/profile/settings/me');
+                currentPrivacy = currentResponse.data?.privacy || {};
+            } catch (e) {
+                logger.debug('Could not load current privacy settings', { error: e });
+            }
+
+            const updatedPrivacy = {
+                ...currentPrivacy,
+                showOnlineStatus: value,
+            };
             await authenticatedClient.put('/profile/settings', {
-                privacy: {
-                    showOnlineStatus: value
-                }
+                privacy: updatedPrivacy,
             });
         } catch (error) {
             logger.error('Error updating setting', { error });
+            // Revert on failure
+            setShowOnlineStatus(!value);
         }
     };
 

--- a/packages/frontend/app/(app)/settings/privacy/profile-visibility.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/profile-visibility.tsx
@@ -68,18 +68,11 @@ export default function ProfileVisibilityScreen() {
                 profileVisibility: newVisibility
             };
             await authenticatedClient.put('/profile/settings', {
-                privacy: updatedPrivacy
+                privacy: updatedPrivacy,
             });
 
-            // Update cache immediately
-            try {
-                const currentResponse = await authenticatedClient.get('/profile/settings/me');
-                if (currentResponse.data?.privacy) {
-                    await updatePrivacySettingsCache(currentResponse.data.privacy);
-                }
-            } catch (e) {
-                logger.debug('Failed to update privacy settings cache', { error: e });
-            }
+            // Update cache from local state to avoid extra GET
+            await updatePrivacySettingsCache(updatedPrivacy);
 
             setProfileVisibility(newVisibility);
             await alertDialog({

--- a/packages/frontend/app/(app)/settings/privacy/restricted.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/restricted.tsx
@@ -588,7 +588,7 @@ export default function RestrictedUsersScreen() {
                                                     if (userId) {
                                                         handleUnrestrict(userId);
                                                     } else {
-                                                        restrictedLogger.error('No userId found for user');
+                                                        restrictedLogger.error('No userId found for user', { user });
                                                         bottomSheet.setBottomSheetContent(
                                                             <MessageBottomSheet
                                                                 title={t('common.error')}

--- a/packages/frontend/app/(app)/settings/privacy/restricted.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/restricted.tsx
@@ -17,12 +17,9 @@ import { BottomSheetContext } from '@/context/BottomSheetContext';
 import ConfirmBottomSheet from '@/components/common/ConfirmBottomSheet';
 import MessageBottomSheet from '@/components/common/MessageBottomSheet';
 import { EmptyState } from '@/components/common/EmptyState';
+import { createScopedLogger } from '@/lib/logger';
 
-// Production check - disable verbose logging in production
-const IS_DEV = __DEV__;
-const log = IS_DEV ? console.log : () => {};
-const logError = IS_DEV ? console.error : () => {};
-const logWarn = IS_DEV ? console.warn : () => {};
+const restrictedLogger = createScopedLogger('RestrictedUsers');
 
 const IconComponent = Ionicons as any;
 
@@ -55,17 +52,17 @@ export default function RestrictedUsersScreen() {
 
     const loadRestrictedUsers = useCallback(async () => {
         if (!isAuthenticated) {
-            log('[RestrictedUsers] Not authenticated, skipping load');
+            restrictedLogger.debug('Not authenticated, skipping load');
             setLoading(false);
             return;
         }
 
         try {
             setLoading(true);
-            log('[RestrictedUsers] Loading restricted users...');
+            restrictedLogger.debug('Loading restricted users...');
             // Use Oxy services directly
             const restrictedUsersList = await oxyServices.getRestrictedUsers();
-            log('[RestrictedUsers] Oxy response:', restrictedUsersList);
+            restrictedLogger.debug('Oxy response', { count: restrictedUsersList?.length });
             // Extract user IDs from RestrictedUser objects (restrictedId can be string or object)
             let userIds = restrictedUsersList
                 .map((user: any) => {
@@ -82,7 +79,7 @@ export default function RestrictedUsersScreen() {
                 userIds = userIds.filter((id: string) => id !== currentUserId);
             }
 
-            log('[RestrictedUsers] Restricted user IDs (filtered):', userIds);
+            restrictedLogger.debug('Restricted user IDs filtered', { count: userIds.length });
             setRestrictedUserIds(userIds);
 
             if (userIds.length === 0) {
@@ -99,7 +96,7 @@ export default function RestrictedUsersScreen() {
                 const batch = userIds.slice(i, i + BATCH_SIZE);
                 const batchPromises = batch.map(async (userId: string) => {
                     try {
-                        log(`[RestrictedUsers] Fetching user details for: ${userId}`);
+                        restrictedLogger.debug(`Fetching user details for: ${userId}`);
 
                         // Use usersStore's ensureById which tries multiple methods and caches
                         const { useUsersStore } = await import('@/stores/usersStore');
@@ -112,39 +109,39 @@ export default function RestrictedUsersScreen() {
                                 try {
                                     return await svc.getProfileById(id);
                                 } catch (e) {
-                                    log(`[RestrictedUsers] getProfileById failed for ${id}`);
+                                    restrictedLogger.debug(`getProfileById failed for ${id}`);
                                 }
                             }
                             if (typeof svc.getProfile === 'function') {
                                 try {
                                     return await svc.getProfile(id);
                                 } catch (e) {
-                                    log(`[RestrictedUsers] getProfile failed for ${id}`);
+                                    restrictedLogger.debug(`getProfile failed for ${id}`);
                                 }
                             }
                             if (typeof svc.getUserById === 'function') {
                                 try {
                                     return await svc.getUserById(id);
                                 } catch (e) {
-                                    log(`[RestrictedUsers] getUserById failed for ${id}`);
+                                    restrictedLogger.debug(`getUserById failed for ${id}`);
                                 }
                             }
                             if (typeof svc.getUser === 'function') {
                                 try {
                                     return await svc.getUser(id);
                                 } catch (e) {
-                                    log(`[RestrictedUsers] getUser failed for ${id}`);
+                                    restrictedLogger.debug(`getUser failed for ${id}`);
                                 }
                             }
                             return null;
                         };
 
                         const user = await usersState.ensureById(String(userId), loader);
-                        log(`[RestrictedUsers] Found user for ${userId}:`, user ? 'yes' : 'no');
+                        restrictedLogger.debug(`Found user for ${userId}: ${user ? 'yes' : 'no'}`);
 
                         // If we couldn't fetch user details, create a minimal user object
                         if (!user) {
-                            log(`[RestrictedUsers] Creating fallback user object for ${userId}`);
+                            restrictedLogger.debug(`Creating fallback user object for ${userId}`);
                             return {
                                 id: userId,
                                 username: userId.substring(0, 8) + '...',
@@ -154,7 +151,7 @@ export default function RestrictedUsersScreen() {
 
                         return user;
                     } catch (error) {
-                        logWarn(`[RestrictedUsers] Failed to fetch user ${userId}:`, error);
+                        restrictedLogger.warn(`Failed to fetch user ${userId}`, { error });
                         // Return fallback user object instead of null
                         return {
                             id: userId,
@@ -167,11 +164,10 @@ export default function RestrictedUsersScreen() {
             }
 
             const users = (await Promise.all(userPromises)).filter(Boolean) as RestrictedUser[];
-            log('[RestrictedUsers] Loaded users:', users.length);
+            restrictedLogger.debug(`Loaded ${users.length} users`);
             setRestrictedUsers(users);
         } catch (error: any) {
-            logError('[RestrictedUsers] Error loading restricted users:', error);
-            logError('[RestrictedUsers] Error response:', error.response?.data);
+            restrictedLogger.error('Error loading restricted users', { error, responseData: error.response?.data });
             bottomSheet.setBottomSheetContent(
                 <MessageBottomSheet
                     title={t('common.error')}
@@ -225,7 +221,7 @@ export default function RestrictedUsersScreen() {
                     const { data } = await oxyServices.searchProfiles(query, { limit: 20 });
                     results = Array.isArray(data) ? data : [];
                 } catch (oxyError) {
-                    logWarn('[RestrictedUsers] oxyServices.searchProfiles failed, falling back:', oxyError);
+                    restrictedLogger.warn('oxyServices.searchProfiles failed, falling back', { error: oxyError });
                     results = await searchService.searchUsers(query);
                 }
             } else {
@@ -248,7 +244,7 @@ export default function RestrictedUsersScreen() {
         } catch (error: any) {
             // Ignore abort errors
             if (error.name !== 'AbortError') {
-                logError('Error searching users:', error);
+                restrictedLogger.error('Error searching users', { error });
             }
         } finally {
             if (!abortController.signal.aborted) {
@@ -321,7 +317,7 @@ export default function RestrictedUsersScreen() {
             }));
             // Use Oxy services directly
             await oxyServices.restrictUser(userId);
-            log('[RestrictedUsers] User restricted successfully');
+            restrictedLogger.debug('User restricted successfully');
 
             // Reload from server to ensure consistency
             await loadRestrictedUsers();
@@ -337,7 +333,7 @@ export default function RestrictedUsersScreen() {
             );
             bottomSheet.openBottomSheet(true);
         } catch (error: any) {
-            logError('Error restricting user:', error);
+            restrictedLogger.error('Error restricting user', { error });
             // Revert optimistic update on error
             setRestrictedUserIds(prev => prev.filter(id => id !== userId));
             setRestrictedUsers(prev => prev.filter(u => {
@@ -368,7 +364,7 @@ export default function RestrictedUsersScreen() {
 
         const performUnrestrict = async () => {
             try {
-                log('[RestrictedUsers] Unrestricting user:', userId);
+                restrictedLogger.debug(`Unrestricting user: ${userId}`);
 
                 // Optimistically remove from list
                 setRestrictedUserIds(prev => prev.filter(id => id !== userId));
@@ -379,7 +375,7 @@ export default function RestrictedUsersScreen() {
 
                 // Use Oxy services directly
                 await oxyServices.unrestrictUser(userId);
-                log('[RestrictedUsers] User unrestricted successfully');
+                restrictedLogger.debug('User unrestricted successfully');
 
                 // Reload from server to ensure consistency
                 await loadRestrictedUsers();
@@ -394,8 +390,7 @@ export default function RestrictedUsersScreen() {
                 );
                 bottomSheet.openBottomSheet(true);
             } catch (error: any) {
-                logError('[RestrictedUsers] Error unrestricting user:', error);
-                logError('[RestrictedUsers] Error response:', error.response?.data);
+                restrictedLogger.error('Error unrestricting user', { error, responseData: error.response?.data });
                 // Revert optimistic update on error
                 if (userToRemove) {
                     setRestrictedUserIds(prev => [...prev, userId]);
@@ -589,11 +584,11 @@ export default function RestrictedUsersScreen() {
                                                 style={{ backgroundColor: colors.error + '20' }}
                                                 activeOpacity={0.7}
                                                 onPress={() => {
-                                                    log('[RestrictedUsers] Unrestrict button pressed for userId:', userId, 'user:', user);
+                                                    restrictedLogger.debug(`Unrestrict button pressed for userId: ${userId}`);
                                                     if (userId) {
                                                         handleUnrestrict(userId);
                                                     } else {
-                                                        logError('[RestrictedUsers] No userId found for user:', user);
+                                                        restrictedLogger.error('No userId found for user');
                                                         bottomSheet.setBottomSheetContent(
                                                             <MessageBottomSheet
                                                                 title={t('common.error')}

--- a/packages/frontend/app/(app)/settings/privacy/restricted.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/restricted.tsx
@@ -584,7 +584,7 @@ export default function RestrictedUsersScreen() {
                                                 style={{ backgroundColor: colors.error + '20' }}
                                                 activeOpacity={0.7}
                                                 onPress={() => {
-                                                    restrictedLogger.debug(`Unrestrict button pressed for userId: ${userId}`);
+                                                    restrictedLogger.debug('Unrestrict button pressed', { userId, user });
                                                     if (userId) {
                                                         handleUnrestrict(userId);
                                                     } else {

--- a/packages/frontend/app/(app)/settings/privacy/tags-mentions.tsx
+++ b/packages/frontend/app/(app)/settings/privacy/tags-mentions.tsx
@@ -37,13 +37,27 @@ export default function TagsMentionsScreen() {
 
     const updateSetting = async (field: 'allowTags' | 'allowMentions', value: boolean) => {
         try {
+            // Load current settings first to preserve other privacy settings
+            let currentPrivacy = {};
+            try {
+                const currentResponse = await authenticatedClient.get('/profile/settings/me');
+                currentPrivacy = currentResponse.data?.privacy || {};
+            } catch (e) {
+                logger.debug('Could not load current privacy settings', { error: e });
+            }
+
+            const updatedPrivacy = {
+                ...currentPrivacy,
+                [field]: value,
+            };
             await authenticatedClient.put('/profile/settings', {
-                privacy: {
-                    [field]: value
-                }
+                privacy: updatedPrivacy,
             });
         } catch (error) {
             logger.error('Error updating setting', { error });
+            // Revert on failure
+            if (field === 'allowTags') setAllowTags(!value);
+            if (field === 'allowMentions') setAllowMentions(!value);
         }
     };
 

--- a/packages/frontend/hooks/useFeedSettings.ts
+++ b/packages/frontend/hooks/useFeedSettings.ts
@@ -18,7 +18,7 @@ export interface FeedSettings {
   };
 }
 
-const DEFAULT_FEED_SETTINGS: FeedSettings = {
+export const DEFAULT_FEED_SETTINGS: FeedSettings = {
   diversity: {
     enabled: true,
     sameAuthorPenalty: 0.95,
@@ -119,10 +119,6 @@ export function useFeedSettings() {
     reloadSettings: loadSettings,
   };
 }
-
-
-
-
 
 
 


### PR DESCRIPTION
## Summary
- **Bug fix**: `online-status.tsx` and `tags-mentions.tsx` were sending only the single changed field via `PUT /profile/settings`, which overwrote all other privacy settings (e.g., toggling online status would reset profile visibility). Now all privacy sub-screens load current settings first and merge changes before saving.
- **Efficiency**: Removed redundant `GET /profile/settings/me` calls after `PUT` in `hide-counts.tsx`, `profile-visibility.tsx`, and `updateAllSettings` -- cache is now updated from local state directly.
- **Code quality**: Replaced ad-hoc `console.log/error/warn` wrappers in `restricted.tsx` with the project's `createScopedLogger` convention, and fixed logger calls to use the correct `(message, metadata)` signature instead of variadic args.
- **Dedup**: Exported `DEFAULT_FEED_SETTINGS` from `useFeedSettings.ts` and removed the duplicate in `feed.tsx`. Imported shared `PrivacySettings` type in `privacy.tsx` instead of redeclaring it.
- **Revert on failure**: Added optimistic revert in `online-status.tsx` and `tags-mentions.tsx` when the save API call fails.

## Test plan
- [ ] Toggle online status on/off, verify other privacy settings (profile visibility, tags/mentions) are not reset
- [ ] Toggle allow tags / allow mentions, verify other privacy settings are preserved
- [ ] Toggle hide counts, verify cache updates correctly without extra network calls
- [ ] Change profile visibility, verify it saves and navigates back correctly
- [ ] Open restricted users screen, verify logging works (no console errors about undefined `log`)
- [ ] Open feed settings, verify presets and sliders still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
