### PR TITLE
fix: global avatar placeholder and file-ID enrichment

### DIFF
--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -50,7 +50,7 @@ function resolveImageSource(fileId: string): string | undefined {
 }
 
 // Stable ref so AvatarPlaceholderProvider never triggers re-renders.
-const avatarPlaceholderConfig = { icon: (size: number) => <MentionAvatarIcon size={size} /> };
+const avatarPlaceholderConfig = { icon: (size: number) => <MentionAvatarIcon size={size * 0.6} /> };
 
 // Types
 interface SplashState {

--- a/packages/frontend/app/_layout.tsx
+++ b/packages/frontend/app/_layout.tsx
@@ -15,8 +15,10 @@ import { AppState, Platform, Text, TextInput, useColorScheme as useRNColorScheme
 import { useAuth } from '@oxyhq/services';
 import { BloomThemeProvider } from '@oxyhq/bloom/theme';
 import { ImageResolverProvider } from '@oxyhq/bloom/image-resolver';
+import { AvatarPlaceholderProvider } from '@oxyhq/bloom/avatar';
 
 // Components
+import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
 import AppSplashScreen from '@/components/AppSplashScreen';
 import { NotificationPermissionGate } from '@/components/NotificationPermissionGate';
 import { ThemedView } from "@/components/ThemedView";
@@ -46,6 +48,9 @@ function resolveImageSource(fileId: string): string | undefined {
   const url = getCachedFileDownloadUrlSync(oxyServices, fileId, 'thumb');
   return url.startsWith('http') ? url : undefined;
 }
+
+// Stable ref so AvatarPlaceholderProvider never triggers re-renders.
+const avatarPlaceholderConfig = { icon: (size: number) => <MentionAvatarIcon size={size} /> };
 
 // Types
 interface SplashState {
@@ -229,16 +234,18 @@ export default function RootLayout() {
 
   return (
     <ImageResolverProvider value={resolveImageSource}>
-      <BloomThemeProvider
-        mode={mode}
-        colorPreset={appColor}
-        onModeChange={setMode}
-        onColorPresetChange={setAppColor}
-      >
-        <ThemedView style={[{ flex: 1 }, colorVars]}>
-          {appContent}
-        </ThemedView>
-      </BloomThemeProvider>
+      <AvatarPlaceholderProvider value={avatarPlaceholderConfig}>
+        <BloomThemeProvider
+          mode={mode}
+          colorPreset={appColor}
+          onModeChange={setMode}
+          onColorPresetChange={setAppColor}
+        >
+          <ThemedView style={[{ flex: 1 }, colorVars]}>
+            {appContent}
+          </ThemedView>
+        </BloomThemeProvider>
+      </AvatarPlaceholderProvider>
     </ImageResolverProvider>
   );
 }

--- a/packages/frontend/components/widgets/WhoToFollowWidget.tsx
+++ b/packages/frontend/components/widgets/WhoToFollowWidget.tsx
@@ -6,7 +6,6 @@ import { useRouter } from "expo-router";
 import { useAuth } from "@oxyhq/services";
 import * as OxyServicesNS from "@oxyhq/services";
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
 import { ThemedText } from "@/components/ThemedText";
 import { BaseWidget } from "./BaseWidget";
 import { useUsersStore, useUserById } from "@/stores/usersStore";
@@ -223,7 +222,7 @@ const FollowRowComponent = React.memo(({ profileData, showBorder = true }: { pro
       style={[styles.webCursor, showBorder && styles.itemBorder]}
     >
       <TouchableOpacity className="flex-row items-center flex-1" onPress={handlePress} activeOpacity={0.7}>
-        <Avatar source={avatarUri} size={32} placeholderColor={getUserPlaceholderColor(cachedUser)}  placeholderIcon={<MentionAvatarIcon size={32 * 0.6} />} />
+        <Avatar source={avatarUri} size={32} placeholderColor={getUserPlaceholderColor(cachedUser)} />
         <View className="ml-2 flex-1 mr-2">
           <UserName
             name={displayName}

--- a/packages/frontend/utils/userEnrichment.ts
+++ b/packages/frontend/utils/userEnrichment.ts
@@ -13,7 +13,7 @@ export function enrichMissingAvatars(
   getUserById: (id: string) => Promise<unknown>,
 ): Promise<void> {
   const store = useUsersStore.getState();
-  const missing = users.filter((u) => !u.avatar);
+  const missing = users.filter((u) => !u.avatar || (typeof u.avatar === 'string' && !u.avatar.startsWith('http')));
   if (missing.length === 0) return Promise.resolve();
 
   return Promise.all(


### PR DESCRIPTION
## Summary
- Add `AvatarPlaceholderProvider` in root layout so all Bloom `Avatar` instances render `MentionAvatarIcon` by default, replacing plain colored circles.
- Broaden `enrichMissingAvatars` filter to also re-fetch profiles whose avatar is a file ID (not a URL), warming the download-URL cache for first render.
- Remove redundant `placeholderIcon` prop from `WhoToFollowWidget` (now handled globally); keep `placeholderColor` for branded backgrounds.

## Test plan
- [ ] Verify avatars without an explicit source show the Mention icon instead of a blank circle
- [ ] Verify users with file-ID avatars get their full profile fetched and avatar URL resolved
- [ ] Verify WhoToFollowWidget still shows colored placeholder backgrounds with the global icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
