### PR TITLE
Remove redundant placeholderIcon props from Avatar usages

### DIFF
--- a/packages/frontend/app/(app)/[username]/connections.tsx
+++ b/packages/frontend/app/(app)/[username]/connections.tsx
@@ -3,7 +3,7 @@ import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { ThemedText } from '@/components/ThemedText';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { StableFollowButton } from '@/components/StableFollowButton';
 import { useLocalSearchParams, router, usePathname } from 'expo-router';
 import { useSafeBack } from '@/hooks/useSafeBack';
@@ -242,7 +242,7 @@ export default function ConnectionsScreen() {
           onPress={() => router.push(`/@${usernameValue}` as any)}
           activeOpacity={0.7}
         >
-          <Avatar source={avatarSource || undefined} size={48}  placeholderIcon={<MentionAvatarIcon size={48 * 0.6} />} />
+          <Avatar source={avatarSource || undefined} size={48} />
           <View className="ml-3 flex-1">
             <ThemedText className="font-semibold text-base text-foreground" numberOfLines={1}>
               {displayName}

--- a/packages/frontend/app/(app)/agora/[id].tsx
+++ b/packages/frontend/app/(app)/agora/[id].tsx
@@ -18,7 +18,7 @@ import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { Loading } from '@oxyhq/bloom/loading';
 import SEO from '@/components/SEO';
 
@@ -35,7 +35,7 @@ import { logger } from '@/lib/logger';
 const ParticipantAvatar = ({ userId, oxyServices }: { userId: string; oxyServices: any }) => {
   const profile = useUserById(userId);
   const avatarUri = getAvatarUrl(profile, oxyServices);
-  return <Avatar size={32} source={avatarUri} shape="squircle"  placeholderIcon={<MentionAvatarIcon size={32 * 0.6} />} />;
+  return <Avatar size={32} source={avatarUri} shape="squircle" />;
 };
 
 // Host info with resolved profile
@@ -46,7 +46,7 @@ const HostInfo = ({ hostId, oxyServices, theme }: { hostId: string; oxyServices:
 
   return (
     <View className="flex-row items-center">
-      <Avatar size={48} source={avatarUri} shape="squircle"  placeholderIcon={<MentionAvatarIcon size={48 * 0.6} />} />
+      <Avatar size={48} source={avatarUri} shape="squircle" />
       <View className="flex-1 ml-3">
         <ThemedText type="defaultSemiBold">{displayName}</ThemedText>
         {profile?.username && (

--- a/packages/frontend/app/(app)/feeds.tsx
+++ b/packages/frontend/app/(app)/feeds.tsx
@@ -19,7 +19,7 @@ import { Header } from '@/components/Header';
 import { IconButton, FloatingActionButton as FAB } from '@/components/ui/Button';
 import { ThemedView } from '@/components/ThemedView';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import SEO from '@/components/SEO';
 
 import { getData, storeData } from '@/utils/storage';
@@ -97,7 +97,7 @@ const FeedRow = ({
       onPress={() => router.push(`/feeds/${item._id || item.id}`)}
       activeOpacity={0.7}
     >
-      <Avatar source={item.avatar || undefined} size={36}  placeholderIcon={<MentionAvatarIcon size={36 * 0.6} />} />
+      <Avatar source={item.avatar || undefined} size={36} />
       <View className="flex-1 gap-0.5">
         <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
           {item.title || 'Untitled Feed'}

--- a/packages/frontend/app/(app)/feeds/[id].tsx
+++ b/packages/frontend/app/(app)/feeds/[id].tsx
@@ -26,7 +26,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { ComposeIcon } from '@/assets/icons/compose-icon';
 import { FloatingActionButton as FAB } from '@/components/ui/Button';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { getData, storeData } from '@/utils/storage';
 import { formatCompactNumber } from '@/utils/formatNumber';
 import StarRating from '@/components/StarRating';
@@ -94,7 +94,7 @@ const FeedHeaderBar = React.memo(function FeedHeaderBar({
         {({ pressed }) => (
           <>
             <View style={[headerStyles.pressHighlight, pressed && { opacity: 1 }]} className="bg-secondary" />
-            <Avatar source={feed.avatar} size={36}  placeholderIcon={<MentionAvatarIcon size={36 * 0.6} />} />
+            <Avatar source={feed.avatar} size={36} />
             <View className="flex-1">
               <Text className="text-[15px] font-bold leading-snug text-foreground" numberOfLines={2}>
                 {feed.title}
@@ -162,7 +162,7 @@ const FeedInfoContent = React.memo(function FeedInfoContent({
     <View className="gap-4 px-5 pb-8 pt-2">
       {/* Avatar + title + share */}
       <View className="flex-row items-center gap-3.5">
-        <Avatar source={feed.avatar} size={48}  placeholderIcon={<MentionAvatarIcon size={48 * 0.6} />} />
+        <Avatar source={feed.avatar} size={48} />
         <View className="flex-1 gap-0.5">
           <Text className="text-2xl font-bold leading-tight text-foreground" numberOfLines={2}>
             {feed.title}
@@ -283,7 +283,7 @@ const ProfilesTab = React.memo(function ProfilesTab({ members }: { members: Memb
           onPress={() => router.push(`/@${m.username}` as any)}
           activeOpacity={0.7}
         >
-          <Avatar source={m.avatar} size={44}  placeholderIcon={<MentionAvatarIcon size={44 * 0.6} />} />
+          <Avatar source={m.avatar} size={44} />
           <View className="flex-1 gap-0.5">
             <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
               {m.username}
@@ -527,7 +527,7 @@ const ReviewsTab = React.memo(function ReviewsTab({ feedId }: { feedId: string }
               style={[reviewStyles.reviewCard, { borderBottomColor: theme.colors.border }]}
             >
               <View className="flex-row items-start gap-2.5">
-                <Avatar source={reviewerAvatar} size={36}  placeholderIcon={<MentionAvatarIcon size={36 * 0.6} />} />
+                <Avatar source={reviewerAvatar} size={36} />
                 <View className="flex-1 gap-[3px]">
                   <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
                     {reviewerName}

--- a/packages/frontend/app/(app)/feeds/create.tsx
+++ b/packages/frontend/app/(app)/feeds/create.tsx
@@ -14,7 +14,7 @@ import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { Toggle } from '@/components/Toggle';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useAuth } from '@oxyhq/services';
@@ -281,7 +281,7 @@ const CreateFeedScreen: React.FC = () => {
                   onPress={() => addMember(u)}
                   activeOpacity={0.7}
                 >
-                  <Avatar source={u.avatar} size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+                  <Avatar source={u.avatar} size={40} />
                   <View className="flex-1 gap-px">
                     <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
                       {u.name?.full || u.username}
@@ -303,7 +303,7 @@ const CreateFeedScreen: React.FC = () => {
           {/* Added members */}
           {members.map((m) => (
             <View key={m.id} className="flex-row items-center gap-3 py-2.5 mt-1">
-              <Avatar source={m.avatar} size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+              <Avatar source={m.avatar} size={40} />
               <View className="flex-1 gap-px">
                 <Text className="text-[15px] font-semibold text-foreground" numberOfLines={1}>
                   {m.name?.full || m.username}

--- a/packages/frontend/app/(app)/lists/[id].tsx
+++ b/packages/frontend/app/(app)/lists/[id].tsx
@@ -21,7 +21,7 @@ import { Header } from '@/components/Header';
 import { IconButton } from '@/components/ui/Button';
 import { BackArrowIcon } from '@/assets/icons/back-arrow-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import Feed from '@/components/Feed/Feed';
 import AnimatedTabBar from '@/components/common/AnimatedTabBar';
 import { listsService } from '@/services/listsService';
@@ -395,7 +395,7 @@ function ListMembers({
               onPress={() => router.push(`/profile/${memberId}`)}
               activeOpacity={0.7}
             >
-              <Avatar size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+              <Avatar size={40} />
               <Text className="text-foreground text-[15px] font-medium flex-1" numberOfLines={1}>
                 {memberId}
               </Text>

--- a/packages/frontend/app/(app)/starter-packs/[id].tsx
+++ b/packages/frontend/app/(app)/starter-packs/[id].tsx
@@ -13,7 +13,7 @@ import { useAuth } from '@oxyhq/services';
 import { useHaptics } from '@/hooks/useHaptics';
 import { Ionicons } from '@expo/vector-icons';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { ResponsiveAvatarStack } from '@/components/AvatarStack';
 import SEO from '@/components/SEO';
 import { cn } from '@/lib/utils';
@@ -251,7 +251,7 @@ export default function StarterPackDetailScreen() {
                   activeOpacity={0.7}
                   accessibilityRole="button"
                   accessibilityLabel={`${m.displayName || m.username}, @${m.username}`}>
-                  <Avatar source={m.avatar} size={44}  placeholderIcon={<MentionAvatarIcon size={44 * 0.6} />} />
+                  <Avatar source={m.avatar} size={44} />
                   <View className="flex-1 gap-0.5">
                     {m.displayName && (
                       <ThemedText

--- a/packages/frontend/components/AvatarStack.tsx
+++ b/packages/frontend/components/AvatarStack.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { View, StyleSheet, ViewStyle } from 'react-native';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { ThemedText } from './ThemedText';
 
 /**
@@ -179,7 +179,7 @@ export const ResponsiveAvatarStack = React.memo(function ResponsiveAvatarStack({
               ]}>
               {size && item.uri ? (
                 <View style={StyleSheet.absoluteFill}>
-                  <Avatar source={item.uri} size={size}  placeholderIcon={<MentionAvatarIcon size={size * 0.6} />} />
+                  <Avatar source={item.uri} size={size} />
                 </View>
               ) : (
                 <View

--- a/packages/frontend/components/BottomBar.tsx
+++ b/packages/frontend/components/BottomBar.tsx
@@ -3,7 +3,7 @@ import { Home, HomeActive, Video, VideoActive, ComposeIcon, ComposeIIconActive, 
 import { useRouter, usePathname } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { useAuth } from '@oxyhq/services';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useHaptics } from '@/hooks/useHaptics';
@@ -236,7 +236,7 @@ export const BottomBar = () => {
             onLongPress: handleLongPressProfile,
             label: t('bottomBar.profile'),
             isActive: pathname.startsWith('/@'),
-            icon: <Avatar size={ICON_SIZE + 4} source={user?.avatar} placeholderIcon={<MentionAvatarIcon size={(ICON_SIZE + 4) * 0.6} />} />,
+            icon: <Avatar size={ICON_SIZE + 4} source={user?.avatar} />,
         },
     ], [
         handleHomePress, handlePressVideos, handlePressCompose, handlePressNotifications,

--- a/packages/frontend/components/GroupedNotificationItem.tsx
+++ b/packages/frontend/components/GroupedNotificationItem.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { ThemedText } from './ThemedText';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { cn } from '@/lib/utils';
 import type { GroupedNotification } from '@/utils/groupNotifications';
 import { formatRelativeTimeLocalized } from '@/utils/dateUtils';
@@ -120,7 +120,7 @@ export const GroupedNotificationItem: React.FC<GroupedNotificationItemProps> = (
     >
       {/* Avatar + action badge */}
       <View style={styles.avatarContainer}>
-        <Avatar source={group.actors[0]?.avatar} size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+        <Avatar source={group.actors[0]?.avatar} size={40} />
         <View className="border-background" style={[styles.actionBadge, { backgroundColor: getNotificationColor(group.type) }]}>
           <Ionicons name={getNotificationIcon(group.type) as any} size={12} color="#fff" />
         </View>
@@ -139,7 +139,7 @@ export const GroupedNotificationItem: React.FC<GroupedNotificationItemProps> = (
                 ]}
               >
                 <View className="border-background" style={styles.avatarBorder}>
-                  <Avatar source={actor.avatar} size={24}  placeholderIcon={<MentionAvatarIcon size={24 * 0.6} />} />
+                  <Avatar source={actor.avatar} size={24} />
                 </View>
               </View>
             ))}

--- a/packages/frontend/components/NotificationItem.tsx
+++ b/packages/frontend/components/NotificationItem.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useNotificationTransformer, RawNotification } from '../utils/notificationTransformer';
 import { useAuth } from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import PostItem from './Feed/PostItem';
 import { usePostsStore } from '../stores/postsStore';
 import { ZEmbeddedPost } from '../types/validation';
@@ -231,7 +231,7 @@ export const NotificationItem: React.FC<NotificationItemProps> = ({
             onLongPress={handleLongPress}
         >
             <View style={styles.avatarContainer}>
-                <Avatar source={actorAvatar} size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+                <Avatar source={actorAvatar} size={40} />
                 <View className="border-background" style={[styles.actionBadge, { backgroundColor: getNotificationColor(notification.type) }]}>
                     <Ionicons name={getNotificationIcon(notification.type) as any} size={12} color="#fff" />
                 </View>
@@ -306,7 +306,7 @@ const PostNotificationItem: React.FC<{
                 style={styles.container}
             >
                 <View style={styles.avatarContainer}>
-                    <Avatar size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+                    <Avatar size={40} />
                     <View className="bg-primary border-background" style={styles.actionBadge}>
                         <Ionicons name="create" size={12} color="#fff" />
                     </View>
@@ -326,7 +326,7 @@ const PostNotificationItem: React.FC<{
                 onPress={handleNotificationPress}
             >
                 <View style={styles.avatarContainer}>
-                    <Avatar size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+                    <Avatar size={40} />
                     <View className="bg-primary border-background" style={styles.actionBadge}>
                         <Ionicons name="create" size={12} color="#fff" />
                     </View>

--- a/packages/frontend/components/Post/EngagementListSheet.tsx
+++ b/packages/frontend/components/Post/EngagementListSheet.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '@/components/ui/Button';
 import { CloseIcon } from '@/assets/icons/close-icon';
 import { feedService } from '@/services/feedService';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { EmptyState } from '@/components/common/EmptyState';
@@ -84,7 +84,7 @@ const EngagementListSheet: React.FC<EngagementListSheetProps> = ({ postId, type,
         style={{ borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: 'transparent' }}
         onPress={() => handleUserPress(item.handle)}
       >
-        <Avatar source={item.avatar} size={50} style={{ marginRight: 12 }}  placeholderIcon={<MentionAvatarIcon size={50 * 0.6} />} />
+        <Avatar source={item.avatar} size={50} style={{ marginRight: 12 }} />
         <View className="flex-1">
           <View className="flex-row items-center">
             <Text className="text-foreground text-base font-semibold" numberOfLines={1}>

--- a/packages/frontend/components/Post/PostActions.tsx
+++ b/packages/frontend/components/Post/PostActions.tsx
@@ -6,7 +6,7 @@ import { RepostIcon, RepostIconActive } from '@/assets/icons/repost-icon';
 import { ShareIcon } from '@/assets/icons/share-icon';
 import { AnalyticsIcon } from '@/assets/icons/analytics-icon';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useHaptics } from '@/hooks/useHaptics';
 import { formatCompactNumber } from '@/utils/formatNumber';
@@ -232,7 +232,7 @@ const PostActions: React.FC<Props> = ({
                     { zIndex: 3 - i, borderColor: theme.colors.background },
                   ]}
                 >
-                  <Avatar source={avatarId} size={MINI_AVATAR}  placeholderIcon={<MentionAvatarIcon size={MINI_AVATAR * 0.6} />} />
+                  <Avatar source={avatarId} size={MINI_AVATAR} />
                 </View>
               ))}
             </View>

--- a/packages/frontend/components/Post/PostDetailView.tsx
+++ b/packages/frontend/components/Post/PostDetailView.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mention/shared-types';
 import { usePostsStore } from '@/stores/postsStore';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '../MentionAvatarIcon';
+
 import UserName from '../UserName';
 import PostContentText from './PostContentText';
 import PostLocation from './PostLocation';
@@ -330,7 +330,7 @@ const PostDetailView: React.FC<PostDetailViewProps> = ({ post, onFocusReply }) =
                 <View className="flex-row items-center mb-3">
                     <ProfileHoverCard username={viewPost.user.handle}>
                         <TouchableOpacity activeOpacity={0.7} onPress={goToUser}>
-                            <Avatar source={avatarUri} size={AVATAR_SIZE} placeholderIcon={<MentionAvatarIcon size={AVATAR_SIZE * 0.6} />} style={{ marginRight: 12 }} />
+                            <Avatar source={avatarUri} size={AVATAR_SIZE} style={{ marginRight: 12 }} />
                         </TouchableOpacity>
                     </ProfileHoverCard>
                     <View className="flex-1 mr-2">

--- a/packages/frontend/components/Post/PostHeader.tsx
+++ b/packages/frontend/components/Post/PostHeader.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { Text, View, TouchableOpacity } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import UserName from '../UserName';
 import { ProfileHoverCard } from '../ProfileHoverCard';
 import { useTheme } from '@oxyhq/bloom/theme';
@@ -65,7 +65,7 @@ const PostHeader: React.FC<PostHeaderProps> = ({
       <View className="flex-row items-start justify-between">
         <ProfileHoverCard username={user.handle}>
           <TouchableOpacity activeOpacity={0.7} onPress={onPressAvatar}>
-            <Avatar source={avatarUri} size={avatarSize} placeholderColor={placeholderColor} style={{ marginRight: 12 }}  placeholderIcon={<MentionAvatarIcon size={avatarSize * 0.6} />} />
+            <Avatar source={avatarUri} size={avatarSize} placeholderColor={placeholderColor} style={{ marginRight: 12 }} />
           </TouchableOpacity>
         </ProfileHoverCard>
         <View className="flex-1" style={{ gap: 4 }}>

--- a/packages/frontend/components/RepostScreen.tsx
+++ b/packages/frontend/components/RepostScreen.tsx
@@ -14,7 +14,7 @@ import {
 import { show as toast } from '@oxyhq/bloom/toast';
 import * as Prompt from '@oxyhq/bloom/prompt';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import UserName from "./UserName";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useAuth } from "@oxyhq/services";
@@ -161,7 +161,7 @@ const RepostScreen: React.FC = () => {
                 {/* Original Post */}
                 <View className="py-4 border-b border-border mb-4">
                     <View className="flex-row items-center mb-2">
-                        <Avatar source={originalPost.user.avatar} size={32} style={{ marginRight: 8 }}  placeholderIcon={<MentionAvatarIcon size={32 * 0.6} />} />
+                        <Avatar source={originalPost.user.avatar} size={32} style={{ marginRight: 8 }} />
                         <View className="flex-1">
                             <UserName
                                 name={originalPost.user.name}

--- a/packages/frontend/components/SideBar/index.tsx
+++ b/packages/frontend/components/SideBar/index.tsx
@@ -13,7 +13,7 @@ import { useIsScreenNotMobile, useIsSideBarExpanded } from "@/hooks/useOptimized
 import { useTranslation } from "react-i18next";
 import { SideBarItem } from "./SideBarItem";
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { Home, HomeActive } from "@/assets/icons/home-icon";
 import { Bookmark, BookmarkActive } from "@/assets/icons/bookmark-icon";
 import { Gear, GearActive } from "@/assets/icons/gear-icon";
@@ -93,8 +93,8 @@ export function SideBar({ asDrawer = false, onNavigate }: SideBarProps) {
         },
         ...(user ? [{
             title: t("sidebar.profile"),
-            icon: <Avatar source={avatarUri} size={24} placeholderIcon={<MentionAvatarIcon size={14} />} />,
-            iconActive: <Avatar source={avatarUri} size={24} placeholderIcon={<MentionAvatarIcon size={14} />} />,
+            icon: <Avatar source={avatarUri} size={24} />,
+            iconActive: <Avatar source={avatarUri} size={24} />,
             route: `/@${user.username}`,
         }] : []),
         {

--- a/packages/frontend/components/WhoToFollowTab.tsx
+++ b/packages/frontend/components/WhoToFollowTab.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'expo-router';
 import { useAuth } from '@oxyhq/services';
 import * as OxyServicesNS from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { useUsersStore, useUserById } from '@/stores/usersStore';
 import { enrichMissingAvatars } from '@/utils/userEnrichment';
 import { useTheme } from '@oxyhq/bloom/theme';
@@ -229,7 +229,7 @@ const FollowRow = React.memo(({ item }: { item: any }) => {
         onPress={handlePress}
         activeOpacity={0.7}
       >
-        <Avatar source={avatarUri} size={48}  placeholderIcon={<MentionAvatarIcon size={48 * 0.6} />} />
+        <Avatar source={avatarUri} size={48} />
         <View style={styles.rowTextWrap}>
           <ThemedText className="text-foreground" style={styles.rowTitle}>
             {displayName}

--- a/packages/frontend/components/suggestions/SuggestedUserCard.tsx
+++ b/packages/frontend/components/suggestions/SuggestedUserCard.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import * as OxyServicesNS from '@oxyhq/services';
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { ThemedText } from '@/components/ThemedText';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useUserById } from '@/stores/usersStore';
@@ -74,7 +74,7 @@ export const SuggestedUserCard = memo(function SuggestedUserCard({
       onPress={handlePress}
       activeOpacity={0.7}
     >
-      <Avatar source={user.avatar || cachedUser?.avatar} size={40}  placeholderIcon={<MentionAvatarIcon size={40 * 0.6} />} />
+      <Avatar source={user.avatar || cachedUser?.avatar} size={40} />
       <View className="flex-1 ml-3 mr-3">
         <UserName
           name={displayName}

--- a/packages/frontend/components/widgets/WhoToFollowWidget.tsx
+++ b/packages/frontend/components/widgets/WhoToFollowWidget.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "expo-router";
 import { useAuth } from "@oxyhq/services";
 import * as OxyServicesNS from "@oxyhq/services";
 import { Avatar } from '@oxyhq/bloom/avatar';
-import { MentionAvatarIcon } from '@/components/MentionAvatarIcon';
+
 import { ThemedText } from "@/components/ThemedText";
 import { BaseWidget } from "./BaseWidget";
 import { useUsersStore, useUserById } from "@/stores/usersStore";
@@ -223,7 +223,7 @@ const FollowRowComponent = React.memo(({ profileData, showBorder = true }: { pro
       style={[styles.webCursor, showBorder && styles.itemBorder]}
     >
       <TouchableOpacity className="flex-row items-center flex-1" onPress={handlePress} activeOpacity={0.7}>
-        <Avatar source={avatarUri} size={32} placeholderColor={getUserPlaceholderColor(cachedUser)}  placeholderIcon={<MentionAvatarIcon size={32 * 0.6} />} />
+        <Avatar source={avatarUri} size={32} placeholderColor={getUserPlaceholderColor(cachedUser)} />
         <View className="ml-2 flex-1 mr-2">
           <UserName
             name={displayName}


### PR DESCRIPTION
## Summary
- Removed redundant `placeholderIcon={<MentionAvatarIcon size={...} />}` prop from every `<Avatar>` usage across 20 files
- Removed now-unused `MentionAvatarIcon` imports from those files
- The `AvatarPlaceholderProvider` in the root layout provides the default placeholder, making per-instance props unnecessary

## Test plan
- [ ] Verify avatars still show the MentionAvatarIcon placeholder when no image is loaded
- [ ] Check all screens with avatars: notifications, posts, sidebar, bottom bar, who-to-follow, feeds, lists, starter packs, agora, connections
- [ ] Confirm `placeholderColor` props are preserved (e.g., PostHeader, WhoToFollowWidget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
