### PR TITLE
feat: add EntityFollow model and API routes

### DIFF
--- a/packages/backend/server.ts
+++ b/packages/backend/server.ts
@@ -61,6 +61,7 @@ import roomsRoutes from './src/routes/rooms.routes';
 import recordingsRoutes from './src/routes/recordings.routes';
 import housesRoutes from './src/routes/houses.routes';
 import seriesRoutes from './src/routes/series.routes';
+import entityFollowRoutes from './src/routes/entity-follow.routes';
 import adminRoutes from './src/routes/admin';
 
 // Federation (ActivityPub)
@@ -756,6 +757,7 @@ authenticatedApiRouter.use("/recordings", recordingsRoutes);
 authenticatedApiRouter.use("/houses", housesRoutes);
 authenticatedApiRouter.use("/series", seriesRoutes);
 authenticatedApiRouter.use("/pokes", pokesRoutes);
+authenticatedApiRouter.use("/entity-follows", entityFollowRoutes);
 authenticatedApiRouter.use("/starter-packs", starterPacksRoutes);
 authenticatedApiRouter.use("/admin", adminRoutes);
 

--- a/packages/backend/src/models/EntityFollow.ts
+++ b/packages/backend/src/models/EntityFollow.ts
@@ -1,0 +1,23 @@
+import mongoose, { Schema, Document, Model } from 'mongoose';
+
+export interface IEntityFollow extends Document {
+  userId: string;
+  entityType: string;
+  entityId: string;
+  createdAt: Date;
+}
+
+const EntityFollowSchema = new Schema<IEntityFollow>(
+  {
+    userId: { type: String, required: true, index: true },
+    entityType: { type: String, required: true },
+    entityId: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+EntityFollowSchema.index({ userId: 1, entityType: 1, entityId: 1 }, { unique: true });
+EntityFollowSchema.index({ entityType: 1, entityId: 1 });
+EntityFollowSchema.index({ userId: 1, entityType: 1 });
+
+export const EntityFollow: Model<IEntityFollow> = mongoose.model<IEntityFollow>('EntityFollow', EntityFollowSchema);

--- a/packages/backend/src/routes/entity-follow.routes.ts
+++ b/packages/backend/src/routes/entity-follow.routes.ts
@@ -1,0 +1,217 @@
+import { Router, Response } from 'express';
+import { EntityFollow } from '../models/EntityFollow';
+import { AuthRequest } from '../types/auth';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+const VALID_ENTITY_TYPES = ['hashtag', 'feed', 'list', 'topic'] as const;
+
+function isValidEntityType(type: string): type is (typeof VALID_ENTITY_TYPES)[number] {
+  return (VALID_ENTITY_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * Follow an entity
+ * POST /entity-follows
+ */
+router.post('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const { entityType, entityId } = req.body;
+
+    if (!entityType || !entityId) {
+      return res.status(400).json({ message: 'entityType and entityId are required' });
+    }
+
+    if (!isValidEntityType(entityType)) {
+      return res.status(400).json({ message: `entityType must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const follow = new EntityFollow({ userId, entityType, entityId });
+    await follow.save();
+
+    logger.debug(`User ${userId} followed ${entityType}:${entityId}`);
+
+    res.status(201).json({ follow });
+  } catch (error: any) {
+    if (error?.code === 11000) {
+      return res.status(409).json({ message: 'Already following this entity' });
+    }
+    logger.error('Error creating entity follow:', { userId: req.user?.id, error });
+    res.status(500).json({
+      message: 'Error creating entity follow',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * Unfollow an entity
+ * DELETE /entity-follows
+ */
+router.delete('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const { entityType, entityId } = req.body;
+
+    if (!entityType || !entityId) {
+      return res.status(400).json({ message: 'entityType and entityId are required' });
+    }
+
+    if (!isValidEntityType(entityType)) {
+      return res.status(400).json({ message: `entityType must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const result = await EntityFollow.findOneAndDelete({ userId, entityType, entityId });
+
+    if (!result) {
+      return res.status(404).json({ message: 'Entity follow not found' });
+    }
+
+    logger.debug(`User ${userId} unfollowed ${entityType}:${entityId}`);
+
+    res.json({ message: 'Entity unfollowed successfully' });
+  } catch (error) {
+    logger.error('Error deleting entity follow:', { userId: req.user?.id, error });
+    res.status(500).json({
+      message: 'Error deleting entity follow',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * Check follow status
+ * GET /entity-follows/status?entityType=...&entityId=...
+ */
+router.get('/status', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const entityType = req.query.entityType as string;
+    const entityId = req.query.entityId as string;
+
+    if (!entityType || !entityId) {
+      return res.status(400).json({ message: 'entityType and entityId query params are required' });
+    }
+
+    if (!isValidEntityType(entityType)) {
+      return res.status(400).json({ message: `entityType must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const follow = await EntityFollow.findOne({ userId, entityType, entityId });
+
+    res.json({ isFollowing: !!follow });
+  } catch (error) {
+    logger.error('Error checking entity follow status:', { userId: req.user?.id, error });
+    res.status(500).json({
+      message: 'Error checking entity follow status',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * List current user's entity follows
+ * GET /entity-follows?type=...&limit=...&cursor=...
+ */
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const type = req.query.type as string | undefined;
+    const limit = Math.min(Math.max(parseInt(String(req.query.limit || 20), 10), 1), 50);
+    const cursor = req.query.cursor as string | undefined;
+
+    if (type && !isValidEntityType(type)) {
+      return res.status(400).json({ message: `type must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const query: any = { userId };
+    if (type) {
+      query.entityType = type;
+    }
+    if (cursor) {
+      query._id = { $lt: cursor };
+    }
+
+    const follows = await EntityFollow.find(query)
+      .sort({ _id: -1 })
+      .limit(limit + 1)
+      .lean();
+
+    const hasMore = follows.length > limit;
+    const results = hasMore ? follows.slice(0, limit) : follows;
+    const nextCursor = hasMore && results.length > 0 ? String(results[results.length - 1]._id) : undefined;
+
+    res.json({ follows: results, hasMore, nextCursor });
+  } catch (error) {
+    logger.error('Error listing entity follows:', { userId: req.user?.id, error });
+    res.status(500).json({
+      message: 'Error listing entity follows',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * List followers of an entity
+ * GET /entity-follows/:entityType/:entityId/followers?limit=...&cursor=...
+ */
+router.get('/:entityType/:entityId/followers', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+
+    const entityType = req.params.entityType as string;
+    const entityId = req.params.entityId as string;
+
+    if (!isValidEntityType(entityType)) {
+      return res.status(400).json({ message: `entityType must be one of: ${VALID_ENTITY_TYPES.join(', ')}` });
+    }
+
+    const limit = Math.min(Math.max(parseInt(String(req.query.limit || 20), 10), 1), 50);
+    const cursor = req.query.cursor as string | undefined;
+
+    const query: any = { entityType, entityId };
+    if (cursor) {
+      query._id = { $lt: cursor };
+    }
+
+    const followers = await EntityFollow.find(query)
+      .sort({ _id: -1 })
+      .limit(limit + 1)
+      .lean();
+
+    const hasMore = followers.length > limit;
+    const results = hasMore ? followers.slice(0, limit) : followers;
+    const nextCursor = hasMore && results.length > 0 ? String(results[results.length - 1]._id) : undefined;
+
+    res.json({ followers: results, hasMore, nextCursor });
+  } catch (error) {
+    logger.error('Error listing entity followers:', { entityType: req.params.entityType, entityId: req.params.entityId, error });
+    res.status(500).json({
+      message: 'Error listing entity followers',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+export default router;

--- a/packages/frontend/components/Profile/hooks/useProfileScroll.ts
+++ b/packages/frontend/components/Profile/hooks/useProfileScroll.ts
@@ -24,6 +24,7 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
     scrollY,
     createAnimatedScrollHandler,
     registerScrollable,
+    setScrollY,
   } = useLayoutScroll();
 
   // Refs - using any for ScrollView ref due to Animated wrapper complexity
@@ -66,9 +67,12 @@ export function useProfileScroll({ profileId, currentTab }: UseProfileScrollOpti
     scrollRef.current = node;
     clearRegistration();
     if (node && registerScrollable) {
+      // Reset shared scrollY so header animations start from 0
+      // (prevents stale scroll position from a previous screen hiding the banner)
+      setScrollY(0);
       unregisterRef.current = registerScrollable(node);
     }
-  }, [clearRegistration, registerScrollable]);
+  }, [clearRegistration, registerScrollable, setScrollY]);
 
   // Scroll event handler with throttling and infinite scroll
   const handleScrollEvent = useCallback((event: any) => {


### PR DESCRIPTION
## Summary
- Add `EntityFollow` Mongoose model with compound unique index on (userId, entityType, entityId)
- Add `/entity-follows` API routes: create (POST), delete (DELETE), status check (GET /status), list user follows (GET /), list entity followers (GET /:entityType/:entityId/followers)
- Validates entityType against allowed values: hashtag, feed, list, topic
- All endpoints require authentication, use cursor-based pagination

## Test plan
- [ ] POST /entity-follows with valid entityType creates a follow record
- [ ] POST /entity-follows with duplicate returns 409
- [ ] DELETE /entity-follows removes existing follow
- [ ] GET /entity-follows/status returns correct isFollowing boolean
- [ ] GET /entity-follows returns paginated list filtered by optional type
- [ ] GET /entity-follows/:entityType/:entityId/followers returns paginated followers
- [ ] Invalid entityType returns 400
- [ ] Unauthenticated requests return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
