### PR TITLE
feat: add entity follow frontend (service, store, hook, button)

### DIFF
--- a/packages/frontend/components/EntityFollowButton.tsx
+++ b/packages/frontend/components/EntityFollowButton.tsx
@@ -1,0 +1,96 @@
+import React, { memo } from 'react';
+import { TouchableOpacity, Text, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { useFollowEntity } from '@/hooks/useFollowEntity';
+import { useTheme } from '@oxyhq/bloom/theme';
+import { useTranslation } from 'react-i18next';
+
+interface EntityFollowButtonProps {
+  entityType: string;
+  entityId: string;
+  label?: string;
+  followingLabel?: string;
+  size?: 'sm' | 'md';
+}
+
+export const EntityFollowButton = memo(function EntityFollowButton({
+  entityType,
+  entityId,
+  label,
+  followingLabel,
+  size = 'md',
+}: EntityFollowButtonProps) {
+  const { isFollowing, isLoading, toggle } = useFollowEntity(entityType, entityId);
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  const text = isFollowing
+    ? (followingLabel || t('common.following', { defaultValue: 'Following' }))
+    : (label || t('common.follow', { defaultValue: 'Follow' }));
+
+  return (
+    <TouchableOpacity
+      onPress={toggle}
+      disabled={isLoading}
+      activeOpacity={0.8}
+      style={[
+        styles.button,
+        size === 'sm' && styles.buttonSmall,
+        {
+          backgroundColor: isFollowing ? theme.colors.background : theme.colors.primary,
+          borderColor: isFollowing ? theme.colors.border : theme.colors.primary,
+        },
+      ]}
+    >
+      {isLoading ? (
+        <ActivityIndicator size="small" color={isFollowing ? theme.colors.text : '#fff'} />
+      ) : (
+        <Text
+          style={[
+            styles.text,
+            size === 'sm' && styles.textSmall,
+            { color: isFollowing ? theme.colors.text : '#fff' },
+          ]}
+        >
+          {text}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+});
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderRadius: 35,
+    paddingVertical: 6,
+    paddingHorizontal: 16,
+    minWidth: 80,
+    ...Platform.select({
+      web: {},
+      default: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.1,
+        shadowRadius: 4,
+        elevation: 2,
+      },
+    }),
+  },
+  buttonSmall: {
+    paddingVertical: 4,
+    paddingHorizontal: 12,
+    minWidth: 60,
+  },
+  text: {
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  textSmall: {
+    fontSize: 12,
+  },
+});
+
+export default EntityFollowButton;

--- a/packages/frontend/hooks/useFollowEntity.ts
+++ b/packages/frontend/hooks/useFollowEntity.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect } from 'react';
+import { useEntityFollowStore } from '@/stores/entityFollowStore';
+
+export function useFollowEntity(entityType: string, entityId: string) {
+  const key = `${entityType}:${entityId}`;
+  const isFollowing = useEntityFollowStore((s) => s.following[key] ?? false);
+  const isLoading = useEntityFollowStore((s) => s.loading[key] ?? false);
+
+  useEffect(() => {
+    if (entityType && entityId) {
+      useEntityFollowStore.getState().fetchStatus(entityType, entityId);
+    }
+  }, [entityType, entityId]);
+
+  const toggle = useCallback(() => {
+    return useEntityFollowStore.getState().toggleFollow(entityType, entityId);
+  }, [entityType, entityId]);
+
+  return { isFollowing, isLoading, toggle };
+}

--- a/packages/frontend/services/entityFollowService.ts
+++ b/packages/frontend/services/entityFollowService.ts
@@ -1,0 +1,32 @@
+import { authenticatedClient } from '@/utils/api';
+
+class EntityFollowService {
+  async follow(entityType: string, entityId: string): Promise<void> {
+    await authenticatedClient.post('/entity-follows', { entityType, entityId });
+  }
+
+  async unfollow(entityType: string, entityId: string): Promise<void> {
+    await authenticatedClient.delete('/entity-follows', { data: { entityType, entityId } });
+  }
+
+  async getStatus(entityType: string, entityId: string): Promise<boolean> {
+    const res = await authenticatedClient.get('/entity-follows/status', {
+      params: { entityType, entityId },
+    });
+    return res.data?.isFollowing ?? false;
+  }
+
+  async getFollowing(type?: string, limit = 20, cursor?: string): Promise<{
+    items: Array<{ entityType: string; entityId: string; createdAt: string }>;
+    nextCursor?: string;
+    hasMore: boolean;
+  }> {
+    const params: Record<string, any> = { limit };
+    if (type) params.type = type;
+    if (cursor) params.cursor = cursor;
+    const res = await authenticatedClient.get('/entity-follows', { params });
+    return res.data;
+  }
+}
+
+export const entityFollowService = new EntityFollowService();

--- a/packages/frontend/stores/entityFollowStore.ts
+++ b/packages/frontend/stores/entityFollowStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import { entityFollowService } from '@/services/entityFollowService';
+
+interface EntityFollowState {
+  following: Record<string, boolean>;  // key: "type:id"
+  loading: Record<string, boolean>;
+
+  fetchStatus: (entityType: string, entityId: string) => Promise<void>;
+  toggleFollow: (entityType: string, entityId: string) => Promise<void>;
+  setStatus: (entityType: string, entityId: string, isFollowing: boolean) => void;
+}
+
+const key = (type: string, id: string) => `${type}:${id}`;
+
+export const useEntityFollowStore = create<EntityFollowState>((set, get) => ({
+  following: {},
+  loading: {},
+
+  fetchStatus: async (entityType, entityId) => {
+    const k = key(entityType, entityId);
+    if (get().loading[k] || k in get().following) return;
+    set((s) => ({ loading: { ...s.loading, [k]: true } }));
+    try {
+      const isFollowing = await entityFollowService.getStatus(entityType, entityId);
+      set((s) => ({ following: { ...s.following, [k]: isFollowing }, loading: { ...s.loading, [k]: false } }));
+    } catch {
+      set((s) => ({ loading: { ...s.loading, [k]: false } }));
+    }
+  },
+
+  toggleFollow: async (entityType, entityId) => {
+    const k = key(entityType, entityId);
+    const current = get().following[k] ?? false;
+    set((s) => ({ following: { ...s.following, [k]: !current }, loading: { ...s.loading, [k]: true } }));
+    try {
+      if (current) {
+        await entityFollowService.unfollow(entityType, entityId);
+      } else {
+        await entityFollowService.follow(entityType, entityId);
+      }
+      set((s) => ({ loading: { ...s.loading, [k]: false } }));
+    } catch {
+      set((s) => ({ following: { ...s.following, [k]: current }, loading: { ...s.loading, [k]: false } }));
+    }
+  },
+
+  setStatus: (entityType, entityId, isFollowing) => {
+    const k = key(entityType, entityId);
+    set((s) => ({ following: { ...s.following, [k]: isFollowing } }));
+  },
+}));


### PR DESCRIPTION
## Summary
- Add `entityFollowService` wrapping the `/entity-follows` API endpoints (follow, unfollow, status, list)
- Add `useEntityFollowStore` Zustand store with optimistic toggle, dedup fetch guard, and rollback on error
- Add `useFollowEntity` hook exposing `isFollowing`, `isLoading`, and `toggle`
- Add `EntityFollowButton` component with i18n, theme support, and sm/md sizes

## Test plan
- [ ] Render `<EntityFollowButton entityType="topic" entityId="123" />` and verify it fetches status on mount
- [ ] Tap to follow/unfollow and confirm optimistic UI update with server sync
- [ ] Verify duplicate fetches are suppressed (mount same entity twice)
- [ ] Verify rollback on network error
- [ ] Run `npx tsc --noEmit` -- no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/mention/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
